### PR TITLE
Fixes Availability timeout issue in Bulk Save, notify for recent saves

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -60,11 +60,10 @@ function URLopener(open_url, url, wmIsAvailable) {
 
 /* * * API Calls * * */
 
-function savePageNow(atab, page_url, silent = false, options = []) {
+function savePageNow(atab, page_url, silent = false, options = {}) {
   if (isValidUrl(page_url) && isNotExcludedUrl(page_url)) {
-    const data = new URLSearchParams()
+    const data = new URLSearchParams(options)
     data.append('url', page_url) // this is correct!
-    options.forEach(opt => data.append(opt, '1'))
     const timeoutPromise = new Promise((resolve, reject) => {
       setTimeout(() => {
         reject(new Error('timeout'))
@@ -420,7 +419,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     if (isNotExcludedUrl(page_url)) {
       if (message.method && (message.method === 'save')) {
         let silent = message.silent || false
-        let options = (message.options && (message.options !== null)) ? message.options : []
+        let options = (message.options && (message.options !== null)) ? message.options : {}
         savePageNow(atab, page_url, silent, options)
         return true
       } else {
@@ -858,7 +857,7 @@ chrome.contextMenus.onClicked.addListener((click) => {
         } else if (click.menuItemId === 'save') {
           let atab = tabs[0]
           if (isNotExcludedUrl(page_url)) {
-            let options = ['capture_all']
+            let options = { 'capture_all': 1 }
             savePageNow(atab, page_url, false, options)
             return true
           }

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -12,7 +12,7 @@ let saveSuccessCount = 0
 let saveFailedCount = 0
 let totalUrlCount = 0
 let isSaving = false
-let saveOptions = []
+let saveOptions = {}
 
 /* * * UI * * */
 
@@ -182,10 +182,10 @@ function doBulkSaveAll(e) {
   totalUrlCount = bulkSaveQueue.length
   $('#total-count').text(totalUrlCount)
   // reset options
-  saveOptions = []
+  saveOptions = {}
   // due to timeout issues, outlinks not supported right now
-  // if ($('#chk-outlinks').prop('checked') === true) { saveOptions.push('capture_outlinks') }
-  if ($('#chk-screenshot').prop('checked') === true) { saveOptions.push('capture_screenshot') }
+  // if ($('#chk-outlinks').prop('checked') === true) { saveOptions['capture_outlinks'] = 1 }
+  if ($('#chk-screenshot').prop('checked') === true) { saveOptions['capture_screenshot'] = 1 }
   // start saving concurrently
   startSaving()
   for (let i = 0; i < MAX_SAVES; i++) {

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -154,13 +154,17 @@ function isDuplicateURL(url) {
 function initMessageListener() {
   chrome.runtime.onMessage.addListener((message) => {
     if (message && message.error) {
-      // stop if user not logged in
-      if (message.error == "You need to be logged in to use Save Page Now." ){
+      if (message.error.indexOf('logged in') !== -1) {
+        // stop if user not logged in
         stopSaving()
         resetUI()
         $('#not-logged-in').show()
+      } else if (message.error.indexOf('same snapshot') !== -1) {
+        // snapshot already archived within timeframe
+        processStatus('archived', message.url)
+        checkIfFinished()
       }
-    } else if (message && message.message && message.url) {
+    } else if (message) {
       // respond to message
       processStatus(message.message, message.url)
       checkIfFinished()
@@ -186,6 +190,7 @@ function doBulkSaveAll(e) {
   // due to timeout issues, outlinks not supported right now
   // if ($('#chk-outlinks').prop('checked') === true) { saveOptions['capture_outlinks'] = 1 }
   if ($('#chk-screenshot').prop('checked') === true) { saveOptions['capture_screenshot'] = 1 }
+  if ($('#never-saved').prop('checked') === true) { saveOptions['if_not_archived_within'] = '99999d' }
   // start saving concurrently
   startSaving()
   for (let i = 0; i < MAX_SAVES; i++) {
@@ -196,22 +201,9 @@ function doBulkSaveAll(e) {
 // Pop next URL to save off the queue.
 function saveNextInQueue() {
   let curl = bulkSaveQueue.shift()
-  if (curl) {
+  if (curl && (curl in bulkSaveObj)) {
     let saveUrl = bulkSaveObj[curl].url
-    if ($('#never-saved').prop('checked') === true) {
-      // only save URL if not already in archive
-      wmAvailabilityCheck(saveUrl, () => {
-        // already archived
-        processStatus('archived', saveUrl)
-        checkIfFinished()
-      }, () => {
-        // hasn't been archived
-        saveTheURL(saveUrl)
-      })
-    } else {
-      // save all URLs
-      saveTheURL(saveUrl)
-    }
+    saveTheURL(saveUrl)
   }
 }
 

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -11,15 +11,15 @@ function homepage() {
 function doSaveNow() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     let url = searchValue || get_clean_url(tabs[0].url)
-    let options = ['capture_all']
+    let options = { 'capture_all': 1 }
     if ($('#chk-outlinks').prop('checked') === true) {
-      options.push('capture_outlinks')
+      options['capture_outlinks'] = 1
       if ($('#email-outlinks-setting').prop('checked') === true) {
-        options.push('email_result')
+        options['email_result'] = 1
       }
     }
     if ($('#chk-screenshot').prop('checked') === true) {
-      options.push('capture_screenshot')
+      options['capture_screenshot'] = 1
     }
     chrome.runtime.sendMessage({
       message: 'openurl',

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -566,6 +566,10 @@ chrome.runtime.onMessage.addListener(
           $('#spn-back-label').text('Last saved: ' + viewableTimestamp(message.timestamp))
           $('#spn-btn').addClass('flip-inside')
           setupWaybackCount()
+        } else if (message.message === 'save_archived') {
+          // snapshot already archived within timeframe
+          $('#save-progress-bar').hide()
+          $('#spn-front-label').text('Recently Saved')
         } else if (message.message === 'save_start') {
           showSaving()
         } else if (message.message === 'save_error') {


### PR DESCRIPTION
- Fixes #696 timeout issues by removing the Availability API call from Bulk Save and adds an option to SPN instead.
- savePageNow() options converted from array to an object internally.
- Handles a new case when *Save Page Now* clicked, will notify the user if it can't save due to another recent save.
