### PR TITLE
Add null checks to prevent errors

### DIFF
--- a/webextension/scripts/context.js
+++ b/webextension/scripts/context.js
@@ -54,9 +54,9 @@ function singlePageView() {
 
   // Check settings for features
   let features = ['alexa', 'domaintools', 'wbmsummary', 'annotations', 'tagcloud']
-  chrome.storage.local.get(features, (event) => {
-    chrome.storage.local.get(['selectedFeature'], (result) => {
-      let openedFeature = result.selectedFeature
+  chrome.storage.local.get(features, (items) => {
+    chrome.storage.local.get(['selectedFeature'], (settings) => {
+      let openedFeature = (settings) ? settings.selectedFeature : null
       let clickFeature = null
       let countFeature = 0
       let lastFeatureTab = null
@@ -65,7 +65,7 @@ function singlePageView() {
         let featureId = '#' + feature.charAt(0).toUpperCase() + feature.substring(1)
         let featureTabId = featureId + '_tab'
 
-        if (event[feature]) {
+        if (items && items[feature]) {
           countFeature++
           lastFeatureTab = featureTabId
           // Show sidebar menu

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -41,8 +41,10 @@ let searchValue
 let private_before_state
 
 function initPrivateState() {
-  chrome.storage.local.get(['private_before_state'], (event) => {
-    private_before_state = new Set(event.private_before_state)
+  chrome.storage.local.get(['private_before_state'], (settings) => {
+    if (settings && settings.private_before_state) {
+      private_before_state = new Set(settings.private_before_state)
+    }
   })
 }
 
@@ -50,7 +52,7 @@ function initPrivateState() {
 function fixedEncodeURIComponent(str) {
   return encodeURIComponent(str).replace(/[!'()*]/g, function(c) {
     return '%' + c.charCodeAt(0).toString(16)
-  });
+  })
 }
 
 /* * * Browser Detection * * */
@@ -395,7 +397,11 @@ function getUrlByParameter(name) {
 
 function openByWindowSetting(url, op = null, cb) {
   if (op === null) {
-    chrome.storage.local.get(['view_setting'], (event) => { opener(url, event.view_setting, cb) })
+    chrome.storage.local.get(['view_setting'], (settings) => {
+      if (settings) { // OK if view_setting undefined
+        opener(url, settings.view_setting, cb)
+      }
+    })
   } else {
     opener(url, op, cb)
   }

--- a/webextension/scripts/wikipedia_loader.js
+++ b/webextension/scripts/wikipedia_loader.js
@@ -5,8 +5,8 @@
 
 // This file is loaded every time URL matches '*.wikipedia.org/*' as defined in manifest.json.
 
-chrome.storage.local.get(['wiki_setting'], (event) => {
-  if (event.wiki_setting) {
+chrome.storage.local.get(['wiki_setting'], (settings) => {
+  if (settings && settings.wiki_setting) {
     addCitations()
   }
 })


### PR DESCRIPTION
Adding checks for undefined, mostly from reading from local storage.
Renamed variable to 'settings'.
Should prevent errors from showing up such as in #704
