### PR TITLE
Fixed null bug in cropPrefix()

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -245,6 +245,8 @@ describe('cropPrefix', () => {
     { 'url': 'ftp://www.example.com/', 'result': 'example.com' },
     { 'url': 'https://example.com/foo/https://www.example.org/', 'result': 'example.com/foo/https://www.example.org' },
     { 'url': '', 'result': '' },
+    { 'url': null, 'result': null },
+    { 'url': undefined, 'result': null },
 ]
   test_cases.forEach(({ url, result }) => {
     it('should return ' + result + ' on ' + url, () => {

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -230,7 +230,7 @@ function updateRow($row, symbol, bgcolor) {
 // Update an individual URL item in the list container.
 function processStatus(msg, url) {
   let curl = cropPrefix(url)
-  if (curl in bulkSaveObj) {
+  if (curl && (curl in bulkSaveObj)) {
     let $row = bulkSaveObj[curl].row
     if ($row) {
       if (msg === 'save_start') {

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -173,8 +173,8 @@ function getWaybackCount(url, onSuccess, onFail) {
  * Checks Wayback Machine API for url snapshot
  */
 function wmAvailabilityCheck(url, onsuccess, onfail) {
-  var requestUrl = hostURL + 'wayback/available'
-  var requestParams = 'url=' + fixedEncodeURIComponent(url)
+  const requestUrl = hostURL + 'wayback/available'
+  const requestParams = 'url=' + fixedEncodeURIComponent(url)
   fetch(requestUrl, {
     method: 'POST',
     headers: new Headers({
@@ -235,7 +235,7 @@ function makeValidURL(url) {
 function cropPrefix(url) {
   if (typeof url === 'string') {
     if (url.slice(-1) === '/') { url = url.slice(0, -1) }
-    let re = /^(?:[a-z]+\:\/\/)?(?:www\.)?(.*)$/
+    let re = /^(?:[a-z]+:\/\/)?(?:www\.)?(.*)$/
     let match = re.exec(url)
     return match[1]
   }
@@ -437,7 +437,7 @@ function opener(url, option, callback) {
 }
 
 function notify(message, callback) {
-  var options = {
+  let options = {
     type: 'basic',
     title: 'WayBack Machine',
     message: message,

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -231,11 +231,15 @@ function makeValidURL(url) {
 
 // Returns substring of URL after :// not including "www." if present.
 // Also crops trailing slash.
+// Returns null if match not found, or if url is not a string.
 function cropPrefix(url) {
-  if (url.slice(-1) === '/') { url = url.slice(0, -1) }
-  let re = /^(?:[a-z]+\:\/\/)?(?:www\.)?(.*)$/
-  let match = re.exec(url)
-  return match[1]
+  if (typeof url === 'string') {
+    if (url.slice(-1) === '/') { url = url.slice(0, -1) }
+    let re = /^(?:[a-z]+\:\/\/)?(?:www\.)?(.*)$/
+    let match = re.exec(url)
+    return match[1]
+  }
+  return null
 }
 
 // Function to check whether it is a valid URL or not


### PR DESCRIPTION
Bug fix for undefined or null URL passed to cropPrefix()

```
Error in event handler: TypeError: Cannot read property 'slice' of undefined

scripts/utils.js:235 (cropPrefix)
scripts/bulk-save.js:232 (processStatus)
scripts/bulk-save.js:169 (anonymous function)

// Returns substring of URL after :// not including "www." if present.
// Also crops trailing slash.
function cropPrefix(url) {
  if (url.slice(-1) === '/') { url = url.slice(0, -1) }
  let re = /^(?:[a-z]+\:\/\/)?(?:www\.)?(.*)$/
  let match = re.exec(url)
  return match[1]
}

```