### PR TITLE
added missing utf8 encoding declaration

### DIFF
--- a/webextension/dnserror.html
+++ b/webextension/dnserror.html
@@ -1,5 +1,8 @@
+<!DOCTYPE html>
 <html>
   <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <link rel="stylesheet" type="text/css" href="css/archive.css">
     <title id="title1"></title>
   </head>


### PR DESCRIPTION
This fixes the following Firefox console error when **dnserror.html** is loaded when a domain doesn't exist.

> The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.

