### PR TITLE
Firefox Compatibility Fixes

### DIFF
--- a/webextension/scripts/archive.js
+++ b/webextension/scripts/archive.js
@@ -24,15 +24,15 @@ const ERROR_CODE_DIC = {
 
 // appending css to the popup
 function appendStyle() {
-  const url = chrome.extension.getURL('css/archive.css')
+  const url = chrome.runtime.getURL('css/archive.css')
   return `<link rel="stylesheet" type="text/css" href=${url}>`
 }
 
 // appending the actual dom of popup
 function appendHTML(url, code) {
   const title = ERROR_CODE_DIC[code]
-  const close = chrome.extension.getURL('images/close.svg')
-  const logo = chrome.extension.getURL('images/wayback-light.png')
+  const close = chrome.runtime.getURL('images/close.svg')
+  const logo = chrome.runtime.getURL('images/wayback-light.png')
   const caption = 'View a saved version courtesy of the'
   const archive = 'View Archived Version'
   return `

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -47,11 +47,8 @@ function URLopener(open_url, url, wmIsAvailable) {
     wmAvailabilityCheck(url, () => {
       openByWindowSetting(open_url)
     }, () => {
-      if (isFirefox) {
-        notify('This page has not been archived.')
-      } else {
-        alert('This page has not been archived.')
-      }
+      const msg = 'This page has not been archived.'
+      if (isFirefox) { notify(msg) } else { alert(msg) }
     })
   } else {
     openByWindowSetting(open_url)
@@ -896,7 +893,8 @@ chrome.contextMenus.onClicked.addListener((click) => {
         let open_url = wayback_url + page_url
         URLopener(open_url, page_url, true)
       } else {
-        alert('This URL is in the list of excluded URLs')
+        const msg = 'This URL is excluded.'
+        if (isFirefox) { notify(msg) } else { alert(msg) }
       }
     }
   })

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -385,7 +385,7 @@ chrome.webRequest.onErrorOccurred.addListener((details) => {
     chrome.storage.local.get(['not_found_setting', 'agreement'], (settings) => {
       if (settings && settings.not_found_setting && settings.agreement) {
         wmAvailabilityCheck(details.url, (wayback_url, url) => {
-          chrome.tabs.update(details.tabId, { url: chrome.extension.getURL('dnserror.html') + '?wayback_url=' + wayback_url + '&page_url=' + url })
+          chrome.tabs.update(details.tabId, { url: chrome.runtime.getURL('dnserror.html') + '?wayback_url=' + wayback_url + '&page_url=' + url })
         }, () => {})
       }
     })

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -87,7 +87,9 @@ function savePageNow(atab, page_url, silent = false, options = {}) {
         if (('job_id' in res) && (res.job_id !== null)) {
           if (msg.indexOf('same snapshot') !== -1) {
             // snapshot already archived within timeframe
-            chrome.runtime.sendMessage({ message: 'save_archived', error: msg, url: page_url, atab: atab })
+            chrome.runtime.sendMessage({ message: 'save_archived', error: msg, url: page_url, atab: atab }, () => {
+              if (chrome.runtime.lastError) { console.log(chrome.runtime.lastError) }
+            })
             if (!silent) { notify(msg) }
           } else {
             // call status during save
@@ -96,7 +98,9 @@ function savePageNow(atab, page_url, silent = false, options = {}) {
           }
         } else {
           // handle error
-          chrome.runtime.sendMessage({ message: 'save_error', error: msg, url: page_url, atab: atab })
+          chrome.runtime.sendMessage({ message: 'save_error', error: msg, url: page_url, atab: atab }, () => {
+            if (chrome.runtime.lastError) { console.log(chrome.runtime.lastError) }
+          })
           if (!silent) { notify('Error: ' + msg) }
         }
         // show resources during save
@@ -118,7 +122,9 @@ function savePageNow(atab, page_url, silent = false, options = {}) {
       })
       .catch(() => {
         // handle http errors
-        chrome.runtime.sendMessage({ message: 'save_error', error: 'Save Error', url: page_url, atab: atab })
+        chrome.runtime.sendMessage({ message: 'save_error', error: 'Save Error', url: page_url, atab: atab }, () => {
+          if (chrome.runtime.lastError) { console.log(chrome.runtime.lastError) }
+        })
       })
   }
 }
@@ -151,6 +157,8 @@ async function validate_spn(atab, job_id, silent = false, page_url) {
       message: 'save_start',
       atab: atab,
       url: page_url
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
     addToolbarState(atab, 'S')
 
@@ -184,6 +192,8 @@ async function validate_spn(atab, job_id, silent = false, page_url) {
           message: 'resource_list_show',
           data: data,
           url: page_url
+        }, () => {
+          if (chrome.runtime.lastError) { }
         })
       })
       .catch((err) => {
@@ -191,6 +201,8 @@ async function validate_spn(atab, job_id, silent = false, page_url) {
           message: 'resource_list_show',
           data: err,
           url: page_url
+        }, () => {
+          if (chrome.runtime.lastError) { }
         })
       })
   }
@@ -206,6 +218,8 @@ async function validate_spn(atab, job_id, silent = false, page_url) {
       timestamp: vdata.timestamp,
       atab: atab,
       url: page_url
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
     // notify
     if (!silent) {
@@ -230,6 +244,8 @@ async function validate_spn(atab, job_id, silent = false, page_url) {
       error: vdata.message,
       url: page_url,
       atab: atab
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
     // notify
     if (!silent) {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -401,16 +401,9 @@ chrome.webRequest.onCompleted.addListener((details) => {
       details.statusCode >= 400 && isNotExcludedUrl(details.url)) {
       globalStatusCode = details.statusCode
       wmAvailabilityCheck(details.url, (wayback_url, url) => {
-        chrome.tabs.executeScript(tabId, {
-          file: 'scripts/archive.js'
-        }, () => {
-          if (chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')) {
-            chrome.tabs.sendMessage(tabId, {
-              type: 'SHOW_BANNER',
-              wayback_url: wayback_url,
-              page_url: url,
-              status_code: 999
-            })
+        chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
+          if (chrome.runtime.lastError) {
+            console.log('Could not inject banner. statusCode: ' + details.statusCode)
           } else {
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -401,10 +401,10 @@ chrome.webRequest.onCompleted.addListener((details) => {
         chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
           if (chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')) {
             chrome.tabs.sendMessage(tabId, {
-             type: 'SHOW_BANNER',
-             wayback_url: wayback_url,
-             page_url: url,
-             status_code: 999
+              type: 'SHOW_BANNER',
+              wayback_url: wayback_url,
+              page_url: url,
+              status_code: 999
             })
           } else {
             chrome.tabs.sendMessage(tabId, {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -399,8 +399,13 @@ chrome.webRequest.onCompleted.addListener((details) => {
       globalStatusCode = details.statusCode
       wmAvailabilityCheck(details.url, (wayback_url, url) => {
         chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
-          if (chrome.runtime.lastError) {
-            console.log('Could not inject banner. statusCode: ' + details.statusCode)
+          if (chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')) {
+            chrome.tabs.sendMessage(tabId, {
+             type: 'SHOW_BANNER',
+             wayback_url: wayback_url,
+             page_url: url,
+             status_code: 999
+            })
           } else {
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -216,6 +216,8 @@ function saveTheURL(url) {
     options: saveOptions,
     method: 'save',
     silent: true
+  }, () => {
+    if (chrome.runtime.lastError) { }
   })
 }
 

--- a/webextension/scripts/doi.js
+++ b/webextension/scripts/doi.js
@@ -90,6 +90,7 @@ function getPapers(url) {
       message: 'getCitedPapers',
       query: url
     }, (papers) => {
+      if (chrome.runtime.lastError) { }
       if (papers && papers.status !== 'error') {
         resolve(papers)
       } else {

--- a/webextension/scripts/fact-check.js
+++ b/webextension/scripts/fact-check.js
@@ -24,6 +24,7 @@ const url = getUrlByParameter('url')
 $('#fact-check-url').text(url)
 if (isValidUrl(url) && isNotExcludedUrl(url)) {
   chrome.runtime.sendMessage({ message: 'getFactCheckResults', url: url }, (resp) => {
+    if (chrome.runtime.lastError) { }
     $('.loader').hide()
     $('.facts').show()
     if (resp && resp.json) {

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -52,12 +52,15 @@ function doSaveNow() {
       options: options,
       method: 'save',
       atab: tabs[0]
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
   })
 }
 
 function last_save() {
   checkAuthentication((result) => {
+    if (chrome.runtime.lastError) { }
     if (!(result && result.auth_check)) {
       loginError()
     } else {
@@ -104,6 +107,7 @@ function loginSuccess() {
               message: 'getLastSaveTime',
               page_url: url
             }, (message) => {
+              if (chrome.runtime.lastError) { }
               if (message && (message.message === 'last_save') && message.timestamp) {
                 $('#spn-back-label').text('Last saved: ' + viewableTimestamp(message.timestamp))
                 $('#spn-btn').addClass('flip-inside')
@@ -133,6 +137,8 @@ function recent_capture() {
       wayback_url: 'https://web.archive.org/web/2/',
       page_url: url,
       method: 'recent'
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
   })
 }
@@ -145,6 +151,8 @@ function first_capture() {
       wayback_url: 'https://web.archive.org/web/0/',
       page_url: url,
       method: 'first'
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
   })
 }
@@ -157,6 +165,8 @@ function view_all() {
       wayback_url: 'https://web.archive.org/web/*/',
       page_url: url,
       method: 'viewall'
+    }, () => {
+      if (chrome.runtime.lastError) { }
     })
   })
 }
@@ -208,9 +218,9 @@ function searchTweet() {
 
 // Update the UI when user is using the Search Box.
 function useSearchBox() {
-  chrome.runtime.sendMessage({ message: 'clearCountBadge' })
-  chrome.runtime.sendMessage({ message: 'clearResource' })
-  chrome.runtime.sendMessage({ message: 'clearFactCheck' })
+  chrome.runtime.sendMessage({ message: 'clearCountBadge' }, () => { if (chrome.runtime.lastError) { } })
+  chrome.runtime.sendMessage({ message: 'clearResource' }, () => { if (chrome.runtime.lastError) { } })
+  chrome.runtime.sendMessage({ message: 'clearFactCheck' }, () => { if (chrome.runtime.lastError) { } })
   $('#fact-check-btn').removeClass('btn-purple')
   $('#suggestion-box').text('').hide()
   $('#url-not-supported-msg').hide()
@@ -357,7 +367,9 @@ function show_login_page() {
 function show_all_screens() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     let url = searchValue || get_clean_url(tabs[0].url)
-    chrome.runtime.sendMessage({ message: 'showall', url: url })
+    chrome.runtime.sendMessage({ message: 'showall', url: url }, () => {
+      if (chrome.runtime.lastError) { }
+    })
   })
 }
 
@@ -366,6 +378,7 @@ function borrow_books() {
     const url = tabs[0].url
     if (url.includes('www.amazon') && url.includes('/dp/')) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
+        if (chrome.runtime.lastError) { }
         let state = (result && result.stateArray) ? new Set(result.stateArray) : new Set()
         if (state.has('R')) {
           $('#readbook-container').show()
@@ -406,6 +419,7 @@ function show_news() {
     const news_host = new URL(url).hostname
     if (newshosts.has(news_host)) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
+        if (chrome.runtime.lastError) { }
         let state = (result && result.stateArray) ? new Set(result.stateArray) : new Set()
         if (state.has('R')) {
           $('#tvnews-container').show()
@@ -430,6 +444,7 @@ function show_wikibooks() {
     const url = tabs[0].url
     if (url.match(/^https?:\/\/[\w\.]*wikipedia.org/)) {
       chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
+        if (chrome.runtime.lastError) { }
         let state = (result && result.stateArray) ? new Set(result.stateArray) : new Set()
         if (state.has('R')) {
           // show wikipedia cited books & papers buttons
@@ -464,6 +479,7 @@ function setUpFactCheck() {
       chrome.storage.local.get(['fact_check_setting'], (settings) => {
         if (settings && settings.fact_check_setting) {
           chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
+            if (chrome.runtime.lastError) { }
             let state = (result && result.stateArray) ? new Set(result.stateArray) : new Set()
             if (state.has('F')) {
               // show purple fact-check button
@@ -518,10 +534,14 @@ function setupWaybackCount() {
       let url = tabs[0].url
       if (settings && settings.wm_count_setting && isValidUrl(url) && isNotExcludedUrl(url) && !isArchiveUrl(url)) {
         showWaybackCount(url)
-        chrome.runtime.sendMessage({ message: 'updateCountBadge' })
+        chrome.runtime.sendMessage({ message: 'updateCountBadge' }, () => {
+          if (chrome.runtime.lastError) { }
+        })
       } else {
         clearWaybackCount()
-        chrome.runtime.sendMessage({ message: 'clearCountBadge' })
+        chrome.runtime.sendMessage({ message: 'clearCountBadge' }, () => {
+          if (chrome.runtime.lastError) { }
+        })
       }
     })
   })
@@ -531,6 +551,7 @@ function setupWaybackCount() {
 function showWaybackCount(url) {
   $('#wayback-count-msg').show()
   chrome.runtime.sendMessage({ message: 'getCachedWaybackCount', url: url }, (result) => {
+    if (chrome.runtime.lastError) { }
     if (result && ('total' in result)) {
       // set label
       let text = ''
@@ -569,6 +590,7 @@ function bulkSave() {
 function setupSaveButton() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
+      if (chrome.runtime.lastError) { }
       let state = (result && result.stateArray) ? new Set(result.stateArray) : new Set()
       if (state.has('S')) {
         showSaving()

--- a/webextension/scripts/recommendations.js
+++ b/webextension/scripts/recommendations.js
@@ -53,7 +53,7 @@ function getArticles(url) {
   getDetails(url)
   .then((clips) => {
     $('.loader').hide()
-    if (clips.length > 0 && threshold >= clips[0]['similarity']) {
+    if (clips && (clips.length > 0) && (threshold >= clips[0]['similarity'])) {
       for (let clip of clips) {
         if (threshold >= clip['similarity']) {
           $('#RecommendationTray').append(constructArticles(clip))

--- a/webextension/scripts/recommendations.js
+++ b/webextension/scripts/recommendations.js
@@ -39,6 +39,7 @@ function getDetails(article) {
       message: 'tvnews',
       article: article
     }, (clips) => {
+      if (chrome.runtime.lastError) { }
       if (clips.status !== 'error') {
         resolve(clips)
       } else {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -72,13 +72,19 @@ function saveOptions() {
   setupWaybackCount()
   if (settings.wm_count_setting === false) {
     // additionally clear the cache if setting cleared
-    chrome.runtime.sendMessage({ message: 'clearCountCache' })
+    chrome.runtime.sendMessage({ message: 'clearCountCache' }, () => {
+      if (chrome.runtime.lastError) { }
+    })
   }
 
   if (settings.fact_check_setting === false) {
-    chrome.runtime.sendMessage({ message: 'clearFactCheck' })
+    chrome.runtime.sendMessage({ message: 'clearFactCheck' }, () => {
+      if (chrome.runtime.lastError) { }
+    })
   }
-  chrome.runtime.sendMessage({ message: 'clearResource', settings: settings })
+  chrome.runtime.sendMessage({ message: 'clearResource', settings: settings }, () => {
+    if (chrome.runtime.lastError) { }
+  })
 }
 
 /*

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -441,7 +441,7 @@ function notify(message, callback) {
     type: 'basic',
     title: 'WayBack Machine',
     message: message,
-    iconUrl: chrome.extension.getURL('images/app-icon/app-icon96.png')
+    iconUrl: chrome.runtime.getURL('images/app-icon/app-icon96.png')
   }
   chrome.notifications.create(options, callback)
 }

--- a/webextension/scripts/wikipedia.js
+++ b/webextension/scripts/wikipedia.js
@@ -156,6 +156,7 @@ function wikipediaBooks (url) {
       message: 'getWikipediaBooks',
       query: url
     }, (books) => {
+      if (chrome.runtime.lastError) { }
       if (books) {
         resolve(books)
       } else {

--- a/webextension/scripts/wikipedia.js
+++ b/webextension/scripts/wikipedia.js
@@ -114,7 +114,7 @@ function createDonateAnchor (isbn) {
     })
     .prepend(
       $('<img>')
-        .attr({ 'alt': 'Read', 'src': chrome.extension.getURL('images/icon_color.png') })[0]
+        .attr({ 'alt': 'Read', 'src': chrome.runtime.getURL('images/icon_color.png') })[0]
     )
 }
 function createArchiveAnchor (id) {
@@ -127,7 +127,7 @@ function createArchiveAnchor (id) {
     })
     .prepend(
       $('<img>')
-        .attr({ 'alt': 'Read', 'src': chrome.extension.getURL('images/icon.png') })[0]
+        .attr({ 'alt': 'Read', 'src': chrome.runtime.getURL('images/icon.png') })[0]
     )
 }
 


### PR DESCRIPTION
Some fixes to issue #740 Firefox Compatibility.

Adds dummy checks to chrome.runtime.lastError to suppress console errors.

This error in console `Promise rejected after context unloaded: Actor 'Conduits' destroyed before query 'RuntimeMessage' was resolved` is not fixed due to an unresolved bug in Firefox which I can't fix. It's reported to occur in other extensions here: https://bugzilla.mozilla.org/show_bug.cgi?id=1665380

The `This page uses the non standard property “zoom”` console error is from Bootstrap using `zoom` in CSS. Hopefully updating that will fix it.
