### PR TITLE
Implement Pause & Continue, Copy Links buttons to Bulk Save

### DIFF
--- a/webextension/bulk-save.html
+++ b/webextension/bulk-save.html
@@ -66,6 +66,7 @@
         </div>
         <div id="bulk-save-label">Start Bulk Save</div>
       </button>
+      <button class="btn btn-auto btn-dark-gray" id="pause-btn">Pause</button>
     </div>
 
   </div>

--- a/webextension/bulk-save.html
+++ b/webextension/bulk-save.html
@@ -34,10 +34,15 @@
 
       <div id="list-container" class="container-scrollbar"></div>
 
-      <div class="count-container">
-        <div><span>Saved</span>:&nbsp;<b id="saved-count" class="highlight-color">0</b></div>
-        <div><span>Failed</span>:&nbsp;<b id="failed-count" class="highlight-color">0</b></div>
-        <div><span>Total</span>:&nbsp;<b id="total-count" class="highlight-color">0</b></div>
+      <div id="status-container" class="btn-flex-block">
+        <button class="btn btn-auto btn-dark-gray" id="copy-all-btn">Copy All Links</button>
+        <button class="btn btn-auto btn-dark-gray" id="copy-saved-btn">Copy Saved</button>
+        <button class="btn btn-auto btn-dark-gray" id="copy-unsaved-btn">Copy Unsaved</button>
+        <div class="count-container">
+          <div><span>Saved</span>:&nbsp;<b id="saved-count" class="highlight-color">0</b></div>
+          <div><span>Failed</span>:&nbsp;<b id="failed-count" class="highlight-color">0</b></div>
+          <div><span>Total</span>:&nbsp;<b id="total-count" class="highlight-color">0</b></div>
+        </div>
       </div>
 
       <div class="save-box">

--- a/webextension/css/bulk-save.css
+++ b/webextension/css/bulk-save.css
@@ -48,13 +48,19 @@ p {
 
 .save-container {
     height: 32px;
+    /* width: 50%; */
 }
 
 #bulk-save-btn {
     position: absolute;
     display: block;
     width: 200px;
-    height: 32px;
+    height: 34px;
+}
+
+#pause-btn {
+    position: absolute;
+    left: 220px;
 }
 
 #bulk-save-label {

--- a/webextension/css/bulk-save.css
+++ b/webextension/css/bulk-save.css
@@ -33,7 +33,7 @@ p {
     color: #000;
     flex: 4;
     min-height: 4em;
-    margin: 1em 0;
+    margin-top: 1em;
     word-break: break-all;
     font-size: 14px;
     color: #333;
@@ -118,7 +118,7 @@ p {
 
 .save-box {
     width: auto;
-    margin: 0 0 1em 0;
+    margin: 1em 0 1em 0;
 }
 
 .save-options-container p {
@@ -148,8 +148,12 @@ p {
     border-radius: 5px;
 }
 
+#status-container {
+    margin-bottom: 1em;
+}
+
 .count-container {
-    display: none;
+    flex: 2;
     font-family: Gill Sans Light;
     font-size: 20px;
     text-align: right;

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -85,7 +85,7 @@ function savePageNow(atab, page_url, silent = false, options = {}) {
           if (msg.indexOf('same snapshot') !== -1) {
             // snapshot already archived within timeframe
             chrome.runtime.sendMessage({ message: 'save_archived', error: msg, url: page_url, atab: atab }, () => {
-              if (chrome.runtime.lastError) { console.log(chrome.runtime.lastError.message) }
+              if (chrome.runtime.lastError) { /* skip */ }
             })
             if (!silent) { notify(msg) }
           } else {
@@ -96,7 +96,7 @@ function savePageNow(atab, page_url, silent = false, options = {}) {
         } else {
           // handle error
           chrome.runtime.sendMessage({ message: 'save_error', error: msg, url: page_url, atab: atab }, () => {
-            if (chrome.runtime.lastError) { console.log(chrome.runtime.lastError.message) }
+            if (chrome.runtime.lastError) { /* skip */ }
           })
           if (!silent) { notify('Error: ' + msg) }
         }

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -37,7 +37,7 @@ function startSaving() {
 function stopSaving() {
   isSaving = false
   $('#save-progress-bar').hide()
-  $('#bulk-save-label').text('Save Finished')
+  $('#bulk-save-label').text('Done')
   $('#pause-btn').hide()
   $('#bulk-save-btn').click(closeWindow)
 }

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -26,6 +26,8 @@ function startSaving() {
   $('.add-container').hide()
   $('.save-box').hide()
   $('#bulk-save-label').text('Archiving URLs...')
+  $('#pause-btn').show()
+  $('#pause-btn').click(pauseSaving)
   $('#save-progress-bar').show()
   $('.count-container').show()
 }
@@ -36,11 +38,23 @@ function stopSaving() {
   isSaving = false
   $('#save-progress-bar').hide()
   $('#bulk-save-label').text('Save Finished')
+  $('#pause-btn').hide()
   $('#bulk-save-btn').click(closeWindow)
+}
+
+function pauseSaving() {
+  isSaving = false
+  $('.add-container').show()
+  $('#save-progress-bar').hide()
+  $('#pause-btn').hide()
+  $('#bulk-save-label').text('Continue Bulk Save')
+  $('#bulk-save-btn').click(doContinue)
+  $('#list-container').click(doRemoveURL)
 }
 
 // Reset UI
 function resetUI() {
+  $('#pause-btn').hide()
   $('.count-container').hide()
   $('.add-container').show()
   $('.save-box').show()
@@ -211,8 +225,14 @@ function doBulkSaveAll(e) {
   }
 }
 
+function doContinue(e) {
+  startSaving()
+  saveNextInQueue()
+}
+
 // Pop next URL to save off the queue.
 function saveNextInQueue() {
+  if (!isSaving) { return }
   let curl = bulkSaveQueue.shift()
   if (curl) {
     if (curl in bulkSaveObj) {
@@ -294,7 +314,7 @@ function processStatus(msg, url, wbUrl) {
 
 // Stop saving when counts reach total count.
 function checkIfFinished() {
-  if (isSaving && (saveSuccessCount + saveFailedCount >= totalUrlCount)) {
+  if (saveSuccessCount + saveFailedCount >= totalUrlCount) {
     stopSaving()
   }
 }
@@ -308,4 +328,4 @@ function main() {
   initMessageListener()
 }
 
-main()
+$(main)

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -130,6 +130,7 @@ function addToBulkSave(url) {
     let $span = $('<div class="url-item">').text(url)
     $('#list-container').append($row.append($del, $span))
     bulkSaveObj[curl] = { url: url, row: $row, status: S_NONE }
+    bulkSaveQueue.push(curl)
   }
 }
 
@@ -164,6 +165,7 @@ function doRemoveURL(e) {
 // Click handler to Clear Bulk Save.
 function doClearAll(e) {
   bulkSaveObj = {}
+  bulkSaveQueue = []
   $('#list-container').text('')
 }
 
@@ -201,17 +203,15 @@ function initMessageListener() {
 
 // Click handler to Start Bulk Save.
 function doBulkSaveAll(e) {
-  // prepare queue, exit if empty
-  bulkSaveQueue = Object.keys(bulkSaveObj)
-  if (bulkSaveQueue.length === 0) {
-    $('#empty-list-err').show()
-    return
-  }
   // reset counts
   saveSuccessCount = 0
   saveFailedCount = 0
   totalUrlCount = bulkSaveQueue.length
   $('#total-count').text(totalUrlCount)
+  if (totalUrlCount === 0) {
+    $('#empty-list-err').show()
+    return
+  }
   // reset options
   saveOptions = {}
   // due to timeout issues, outlinks not supported right now
@@ -225,9 +225,17 @@ function doBulkSaveAll(e) {
   }
 }
 
+// Click handler to Continue Bulk Save.
 function doContinue(e) {
-  startSaving()
-  saveNextInQueue()
+  totalUrlCount = bulkSaveQueue.length
+  $('#total-count').text(totalUrlCount)
+  if (totalUrlCount === 0) {
+    $('#empty-list-err').show()
+  } else {
+    startSaving()
+    // TODO: could try upto MAX_SAVES here
+    saveNextInQueue()
+  }
 }
 
 // Pop next URL to save off the queue.

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -158,6 +158,17 @@ function removeFromBulkSave(url) {
   }
 }
 
+// Resets all pending (yellow) and failed URLs stored in bulkSaveMap, re-adds them to the queue.
+function resetAllInBulkSave() {
+  for (let [curl, obj] of bulkSaveMap.entries()) {
+    let $row = obj.row
+    if ($row && ((obj.status === S_SAVING) || (obj.status === S_FAILED))) {
+      updateRow($row, '', 'purple')
+      bulkSaveQueue.push(curl)
+    }
+  }
+}
+
 // Click handler to Add URLs to Bulk Save.
 function doAddURLs(e) {
   $('#empty-list-err').hide()
@@ -255,9 +266,11 @@ function doContinue(e) {
   if (totalUrlCount === 0) {
     $('#empty-list-err').show()
   } else {
+    resetAllInBulkSave()
     startSaving()
-    // TODO: could try upto MAX_SAVES here
-    saveNextInQueue()
+    for (let i = 0; i < MAX_SAVES; i++) {
+      saveNextInQueue()
+    }
   }
 }
 

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -71,6 +71,7 @@ function last_save() {
 
 function loginError() {
   $('#bulk-save-btn').attr('disabled', true)
+  $('#bulk-save-btn').attr('title', 'Log in to use')
   $('#bulk-save-btn').off('click')
   $('#spn-btn').addClass('flip-inside')
   $('#spn-back-label').text('Log In to Save Page')
@@ -94,6 +95,7 @@ function loginSuccess() {
   $('#spn-front-label').parent().removeAttr('disabled')
   $('#spn-btn').off('click')
   $('#bulk-save-btn').removeAttr('disabled')
+  $('#bulk-save-btn').attr('title', '')
   $('#bulk-save-btn').click(bulkSave)
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (tabs && tabs[0]) {


### PR DESCRIPTION
Makes a number of improvements to Bulk Save, including Pause and Continue, which will reset pending items and add them back to the queue for saving. Adds buttons so that the user can copy saved items' Wayback Machine links, or links of unsaved items to try again later.
#731 #741 #743 #754
