### PR TITLE
Variety of Safari bug fixes

### DIFF
--- a/webextension/css/index.css
+++ b/webextension/css/index.css
@@ -259,12 +259,11 @@ a.btn-social, .btn-social {
 }
 
 .btn-social .fa, .btn-social i {
-    backface-visibility: hidden;
-    -moz-backface-visibility: hidden;
     -ms-transform: scale(1);
     -o-transform: scale(1);
     transform: scale(1);
     transition: all .25s;
+    backface-visibility: hidden;
     -webkit-backface-visibility: hidden;
     -webkit-transform: scale(1);
     -webkit-transition: all .25s;
@@ -394,6 +393,7 @@ a.btn-social, .btn-social {
 .flip-front, .flip-back {
     position: absolute;
     backface-visibility: hidden;
+    -webkit-backface-visibility: hidden;
     width: 100%;
 }
 

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "2.999.4",
+  "version": "2.999.5",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -54,9 +54,7 @@
     }
   ],
   "web_accessible_resources": [
-    "css/*",
-    "fonts/*",
-    "images/*",
-    "scripts/*"
+    "css/archive.css",
+    "images/*"
   ]
 }

--- a/webextension/scripts/archive.js
+++ b/webextension/scripts/archive.js
@@ -1,4 +1,5 @@
 // archive.js
+// do NOT use jQuery in this file
 
 let gCloseClicked = false
 let gArchiveClicked = false

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -374,13 +374,17 @@ chrome.browserAction.onClicked.addListener((tab) => {
 chrome.webRequest.onBeforeSendHeaders.addListener(
   rewriteUserAgentHeader,
   { urls: [WB_API_URL] },
-  ['blocking', 'requestHeaders']
+  ['blocking', 'requestHeaders'] // FIXME: not supported in Safari
 )
 
+// Checks for error in page loading such as when a domain doesn't exist.
+// Currently not supported in Safari.
+//
 chrome.webRequest.onErrorOccurred.addListener((details) => {
+  console.log(`webRequest.onErrorOccurred: error: ${details.error}, tabId: ${details.tabId}, url: ${details.url}`) // DEBUG
   if (['net::ERR_NAME_NOT_RESOLVED', 'net::ERR_NAME_RESOLUTION_FAILED',
     'net::ERR_CONNECTION_TIMED_OUT', 'net::ERR_NAME_NOT_RESOLVED', 'NS_ERROR_UNKNOWN_HOST'].indexOf(details.error) >= 0 &&
-    details.tabId > 0) {
+    (details.tabId >= 0)) {
     chrome.storage.local.get(['not_found_setting', 'agreement'], (settings) => {
       if (settings && settings.not_found_setting && settings.agreement) {
         wmAvailabilityCheck(details.url, (wayback_url, url) => {
@@ -391,17 +395,21 @@ chrome.webRequest.onErrorOccurred.addListener((details) => {
   }
 }, { urls: ['<all_urls>'], types: ['main_frame'] })
 
-/**
-* Header callback
-*/
+// Listens for website loading completed for 404-Not-Found popups.
 chrome.webRequest.onCompleted.addListener((details) => {
+
   function tabIsReady(tabId) {
-    if (details.frameId === 0 &&
-      details.statusCode >= 400 && isNotExcludedUrl(details.url)) {
+    console.log(`webRequest.onCompleted: tabIsReady tabId: ${tabId}, frameId: ${details.frameId}, statusCode: ${details.statusCode}`) // DEBUG
+    if ((details.statusCode >= 400) && isNotExcludedUrl(details.url)) {
       globalStatusCode = details.statusCode
-      wmAvailabilityCheck(details.url, (wayback_url, url) => {
-        chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
+      // insert script first, then check wayback machine, then show banner
+      chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
+        console.log(`webRequest.onCompleted: executeScript1`) // DEBUG
+
+        wmAvailabilityCheck(details.url, (wayback_url, url) => {
+          console.log(`webRequest.onCompleted: wayback_url: ${wayback_url}`) // DEBUG
           if (chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')) {
+            console.log(`webRequest.onCompleted: sendMessage1`) // DEBUG
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',
               wayback_url: wayback_url,
@@ -409,6 +417,7 @@ chrome.webRequest.onCompleted.addListener((details) => {
               status_code: 999
             })
           } else {
+            console.log(`webRequest.onCompleted: sendMessage2`) // DEBUG
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',
               wayback_url: wayback_url,
@@ -416,19 +425,24 @@ chrome.webRequest.onCompleted.addListener((details) => {
               status_code: details.statusCode
             })
           }
-        })
-      }, () => {})
-    }
-  }
-  if (details.tabId > 0) {
+        }, () => {}) // wmAvailabilityCheck
+      }) // executeScript
+    } // if
+  } // function
+
+  console.log(`webRequest.onCompleted: url: ${details.url}, tabId: ${details.tabId}`) // DEBUG
+  if (details.tabId >= 0) {
     chrome.storage.local.get(['not_found_setting', 'agreement'], (settings) => {
       if (settings && settings.not_found_setting && settings.agreement) {
         tabIsReady(details.tabId)
+      } else {
+        console.log(`webRequest.onCompleted: NO agreement?`) // DEBUG
       }
     })
   }
 }, { urls: ['<all_urls>'], types: ['main_frame'] })
 
+// Listens for messages to call background functions from other scripts.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (!message) { return }
   if (message.message === 'openurl') {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -351,7 +351,7 @@ function getCachedFactCheck(url, onSuccess, onFail) {
 chrome.runtime.onStartup.addListener((details) => {
   chrome.storage.local.get({ agreement: false }, (settings) => {
     if (settings && settings.agreement) {
-      chrome.browserAction.setPopup({ popup: 'index.html' })
+      chrome.browserAction.setPopup({ popup: chrome.runtime.getURL('index.html') })
     }
   })
 })
@@ -362,11 +362,12 @@ chrome.runtime.onInstalled.addListener((details) => {
   chrome.storage.local.get({ agreement: false }, (settings) => {
     if (settings && settings.agreement) {
       afterAcceptOptions()
-      chrome.browserAction.setPopup({ popup: 'index.html' })
+      chrome.browserAction.setPopup({ popup: chrome.runtime.getURL('index.html') })
     }
   })
 })
 
+// Opens Welcome page if popup not yet set.
 chrome.browserAction.onClicked.addListener((tab) => {
   openByWindowSetting(chrome.runtime.getURL('welcome.html'), 'tab')
 })

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -417,9 +417,14 @@ function doCopyUnsaved() {
 
 // onload
 $(function() {
+  if (chrome.bookmarks) {
+    $('#import-bookmarks-btn').click(doImportBookmarks)
+  } else {
+    // Safari doesn't support reading bookmarks
+    $('#import-bookmarks-btn').hide()
+  }
   $('.btn').click(clearFocus)
   $('#add-url-btn').click(doAddURLs)
-  $('#import-bookmarks-btn').click(doImportBookmarks)
   $('#clear-all-btn').click(doClearAll)
   $('#copy-all-btn').click(doCopyAll)
   $('#copy-saved-btn').click(doCopySaved)

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -319,8 +319,15 @@ function updateRow($row, symbol, bgcolor, url, wbUrl) {
   $del.css('background-color', bgcolor)
   if (url && wbUrl) {
     // replace url-item text with a wayback link.
+    // all this needed to open in a new window in Safari.
     let $span = $row.children('.url-item').first()
-    $span.html(`<a href="${wbUrl}" target="_blank">${url}</a>`)
+    let $ahref = $(`<a href="${wbUrl}">${url}</a>`)
+    $ahref.click(function(e) {
+      e.preventDefault()
+      window.open(this.href, '_blank')
+    })
+    $span.empty()
+    $span.append($ahref)
   }
 }
 

--- a/webextension/scripts/dnserror.js
+++ b/webextension/scripts/dnserror.js
@@ -1,4 +1,5 @@
 // dnserror.js
+// do NOT use jQuery in this file
 
 // from 'archive.js'
 /*   global refreshWayback */
@@ -9,7 +10,7 @@ function getParameterByName(name) {
 }
 
 // onload
-$(function() {
+window.addEventListener('load', function() {
   let page_url = getParameterByName('page_url')
   let wayback_url = getParameterByName('wayback_url')
   document.getElementById('title1').innerHTML = 'Server Not Found'

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -12,6 +12,12 @@ function homepage() {
   openByWindowSetting('https://web.archive.org/')
 }
 
+// If the popup displays, we know user already agreed in Welcome page.
+// This is a fix for Safari resetting the 'agreement' setting.
+function initAgreement() {
+  chrome.storage.local.set({ agreement: true }, () => {})
+}
+
 // Popup tip over settings tab icon after first load.
 function showSettingsTabTip() {
   let tt = $('<div>').append($('<p>').text('There are more great features in Settings!').attr({ 'class': 'setting-tip' }))[0].outerHTML
@@ -664,6 +670,7 @@ function setupSaveListener() {
 $(function() {
   $('#setting-page').hide()
   $('#login-page').hide()
+  initAgreement()
   initActiveTabURL()
   setupNewsClips()
   setupWikiButtons()

--- a/webextension/scripts/resource_list.js
+++ b/webextension/scripts/resource_list.js
@@ -56,6 +56,11 @@ function showResourceData(url_name) {
           document.location.hash = '#refreshed'
           let snapshot_url = 'https://web.archive.org/web/' + vdata.timestamp + '/' + vdata.original_url
           $('#snapshot-url').text('Click to view snapshot').attr('href', snapshot_url).show()
+          $('#snapshot-url').click(function(e) {
+            // forces open in new window in Safari
+            e.preventDefault()
+            window.open(this.href, '_blank')
+          })
         } else if (status === 'error') {
           showError()
           document.location.hash = '#refreshed'

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -88,7 +88,7 @@ const feedbackURLs = {
   chrome: 'https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak/reviews?hl=en',
   chromium: 'https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak/reviews?hl=en',
   firefox: 'https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/',
-  safari: 'https://apps.apple.com/us/app/wayback-machine/id1201888313'
+  safari: 'https://apps.apple.com/us/app/wayback-machine/id1472432422'
 }
 
 const gBrowser = getBrowser()


### PR DESCRIPTION
Strangely, there's some glitching and slowdowns while hovering over popup buttons in Chrome now, where before this only occurred in Safari. Likely due to the massive `style.css` file which I'll work on next.

There's a bug in Safari regarding `manifest.js`: Under `"content_scripts"` the `"matches"` field appears to be ignored by Safari and js and css files in this section are inserted in ALL websites instead of just Wikipedia. Seems to only occur when "Always Allow on Every Website..." button is selected in preferences (which is recommended) but this causes all sorts of problems on websites...
