### PR TITLE
Popup buttons work while viewing Extension pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-machine-webextension",
-  "version": "2.999.6",
+  "version": "2.999.8",
   "description": "A browser extension that interfaces with the internet archive",
   "main": "index.js",
   "directories": {

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -239,7 +239,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1300;
 				TargetAttributes = {
 					C3CBA8AE26E4511100CC9485 = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -466,6 +466,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Wayback Machine Extension/Wayback_Machine_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "Wayback Machine Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -474,7 +475,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.7;
+				MARKETING_VERSION = 2.999.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -486,6 +487,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "Wayback Machine Extension/Wayback_Machine_Extension.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = "Wayback Machine Extension/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -494,7 +496,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.7;
+				MARKETING_VERSION = 2.999.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -509,6 +511,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Wayback Machine/Wayback_Machine.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Wayback Machine/Info.plist";
@@ -517,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.7;
+				MARKETING_VERSION = 2.999.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -531,6 +534,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "Wayback Machine/Wayback_Machine.entitlements";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "Wayback Machine/Info.plist";
@@ -539,7 +543,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.7;
+				MARKETING_VERSION = 2.999.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert').strict
 const getUrlByParameter = require('../webextension/scripts/utils').getUrlByParameter
 const isArchiveUrl = require('../webextension/scripts/utils').isArchiveUrl
 const isValidUrl = require('../webextension/scripts/utils').isValidUrl
-const get_clean_url = require('../webextension/scripts/utils').get_clean_url
+const getCleanUrl = require('../webextension/scripts/utils').getCleanUrl
 const isNotExcludedUrl = require('../webextension/scripts/utils').isNotExcludedUrl
 const badgeCountText = require('../webextension/scripts/utils').badgeCountText
 const timestampToDate = require('../webextension/scripts/utils').timestampToDate
@@ -71,7 +71,7 @@ describe('isValidUrl', () => {
   })
 })
 
-describe('get_clean_url', () => {
+describe('getCleanUrl', () => {
   var test_cases = [
     //Test Case when the URL is https://web.archive.org
     { 'url': 'https://web.archive.org', 'result': 'https://web.archive.org' },
@@ -94,7 +94,7 @@ describe('get_clean_url', () => {
   ]
   test_cases.forEach(({ url, result }) => {
     it('should return ' + result + ' on ' + url, () => {
-      expect(get_clean_url(url)).to.equal(result)
+      expect(getCleanUrl(url)).to.equal(result)
     })
   })
 })

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -73,16 +73,16 @@ describe('isValidUrl', () => {
 
 describe('getCleanUrl', () => {
   var test_cases = [
-    //Test Case when the URL is https://web.archive.org
+    // Test Case when the URL is https://web.archive.org
     { 'url': 'https://web.archive.org', 'result': 'https://web.archive.org' },
 
-    //Test Cases when the URL does not includes 'web.archive.org'
+    // Test Cases when the URL does not includes 'web.archive.org'
     { 'url': 'https://www.google.com/', 'result': 'https://www.google.com/' },
     { 'url': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
     { 'url': 'http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
     { 'url': 'https://apnews.com/', 'result': 'https://apnews.com/' },
 
-    //Test Cases when the URL includes 'web.archive.org'
+    // Test Cases when the URL includes 'web.archive.org'
     { 'url': 'https://web.archive.org/web/*/https://www.google.com/', 'result': 'https://www.google.com/' },
     { 'url': 'https://web.archive.org/web/*/https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
     { 'url': 'https://web.archive.org/web/*/http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
@@ -91,6 +91,12 @@ describe('getCleanUrl', () => {
     { 'url': 'https://web.archive.org/web/20200602155930/https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462', 'result': 'https://www.amazon.in/End-Days-Predictions-Prophecies-Thorndike/dp/1410407462' },
     { 'url': 'https://web.archive.org/web/20200215123917/http://purl.oclc.org/docs/inet96.html', 'result': 'http://purl.oclc.org/docs/inet96.html' },
     { 'url': 'https://web.archive.org/web/20200308013652/https://apnews.com/', 'result': 'https://apnews.com/' },
+
+    // Test for Extension Pages
+    { 'url': 'moz-extension://abcd-1234-efghi/annotations.html?url=https://example.com/', 'result': 'https://example.com/' },
+    { 'url': 'moz-extension://abcd-1234-efghi/annotations.html?url=http://example.com/1234', 'result': 'http://example.com/1234' },
+    { 'url': 'chrome-extension://abcd-1234-efghi/annotations.html?url=https://example.com/', 'result': 'https://example.com/' },
+    { 'url': 'chrome-extension://abcd-1234-efghi/annotations.html?url=http://example.com/1234', 'result': 'http://example.com/1234' },
   ]
   test_cases.forEach(({ url, result }) => {
     it('should return ' + result + ' on ' + url, () => {

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "2.999.7",
+  "version": "2.999.8",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -4,7 +4,7 @@
 // Copyright 2016-2020, Internet Archive
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, get_clean_url, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
+/*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
 /*   global initDefaultOptions, afterAcceptOptions, badgeCountText, getWaybackCount, newshosts, dateToTimestamp, gBrowser, fixedEncodeURIComponent */
 
 let manifest = chrome.runtime.getManifest()
@@ -444,7 +444,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.message === 'saveurl') {
     // Save Page Now
     if (isValidUrl(message.page_url) && isNotExcludedUrl(message.page_url)) {
-      let page_url = get_clean_url(message.page_url)
+      let page_url = getCleanUrl(message.page_url)
       let silent = message.silent || false
       let options = (message.options && (message.options !== null)) ? message.options : {}
       savePageNow(message.atab, page_url, silent, options)
@@ -453,7 +453,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   else if (message.message === 'openurl') {
     // open URL in new tab or window depending on setting
     if (isValidUrl(message.page_url) && isNotExcludedUrl(message.page_url)) {
-      let page_url = get_clean_url(message.page_url)
+      let page_url = getCleanUrl(message.page_url)
       let open_url = message.wayback_url + page_url
       URLopener(open_url, page_url, true)
     }
@@ -496,7 +496,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // sends a url to webpage under current tab (not used)
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs && tabs[0]) {
-        let url = get_clean_url(tabs[0].url)
+        let url = getCleanUrl(tabs[0].url)
         chrome.tabs.sendMessage(tabs[0].id, { url: url })
       }
     })
@@ -521,7 +521,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // update wayback count badge
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs && tabs[0] && isNotExcludedUrl(tabs[0].url)) {
-        let url = get_clean_url(tabs[0].url)
+        let url = getCleanUrl(tabs[0].url)
         updateWaybackCountBadge(tabs[0], url)
       }
     })
@@ -586,7 +586,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
       }
     })
     // checking resources
-    const clean_url = get_clean_url(tab.url)
+    const clean_url = getCleanUrl(tab.url)
     if (isValidUrl(clean_url) === false) { return }
     chrome.storage.local.get(['wiki_setting', 'tvnews_setting'], (settings) => {
       // checking wikipedia books & papers
@@ -630,7 +630,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
       chrome.storage.local.get(['amazon_setting'], (settings) => {
         // checking amazon books settings
         if (settings && settings.amazon_setting) {
-          const url = get_clean_url(tab.url)
+          const url = getCleanUrl(tab.url)
           // checking resource of amazon books
           if (url.includes('www.amazon')) {
             fetch(hostURL + 'services/context/amazonbooks?url=' + url)
@@ -900,7 +900,7 @@ chrome.contextMenus.onClicked.addListener((click) => {
     if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
       let url = click.linkUrl || tabs[0].url
       if (isValidUrl(url) && isNotExcludedUrl(url)) {
-        let page_url = get_clean_url(url)
+        let page_url = getCleanUrl(url)
         let wayback_url
         if (click.menuItemId === 'first') {
           wayback_url = 'https://web.archive.org/web/0/'

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -391,19 +391,18 @@ chrome.webRequest.onErrorOccurred.addListener((details) => {
 
 // Listens for website loading completed for 404-Not-Found popups.
 chrome.webRequest.onCompleted.addListener((details) => {
-
   function tabIsReady(tabId) {
     console.log(`webRequest.onCompleted: tabIsReady tabId: ${tabId}, frameId: ${details.frameId}, statusCode: ${details.statusCode}`) // DEBUG
     if ((details.statusCode >= 400) && isNotExcludedUrl(details.url)) {
       globalStatusCode = details.statusCode
       // insert script first, then check wayback machine, then show banner
       chrome.tabs.executeScript(tabId, { file: '/scripts/archive.js' }, () => {
-        console.log(`webRequest.onCompleted: executeScript1`) // DEBUG
+        console.log('webRequest.onCompleted: executeScript1') // DEBUG
 
         wmAvailabilityCheck(details.url, (wayback_url, url) => {
           console.log(`webRequest.onCompleted: wayback_url: ${wayback_url}`) // DEBUG
           if (chrome.runtime.lastError && chrome.runtime.lastError.message.startsWith('Cannot access contents of url "chrome-error://chromewebdata/')) {
-            console.log(`webRequest.onCompleted: sendMessage1`) // DEBUG
+            console.log('webRequest.onCompleted: sendMessage1') // DEBUG
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',
               wayback_url: wayback_url,
@@ -411,7 +410,7 @@ chrome.webRequest.onCompleted.addListener((details) => {
               status_code: 999
             })
           } else {
-            console.log(`webRequest.onCompleted: sendMessage2`) // DEBUG
+            console.log('webRequest.onCompleted: sendMessage2') // DEBUG
             chrome.tabs.sendMessage(tabId, {
               type: 'SHOW_BANNER',
               wayback_url: wayback_url,
@@ -430,7 +429,7 @@ chrome.webRequest.onCompleted.addListener((details) => {
       if (settings && settings.not_found_setting && settings.agreement) {
         tabIsReady(details.tabId)
       } else {
-        console.log(`webRequest.onCompleted: NO agreement?`) // DEBUG
+        console.log('webRequest.onCompleted: NO agreement?') // DEBUG
       }
     })
   }
@@ -570,9 +569,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 })
 
 chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
-
   if (!isNotExcludedUrl(tab.url)) { return }
-
   if (info.status === 'complete') {
     updateWaybackCountBadge(tab, tab.url)
     chrome.storage.local.get(['auto_archive_setting', 'fact_check_setting'], (settings) => {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -443,7 +443,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (!message) { return }
   if (message.message === 'saveurl') {
     // Save Page Now
-    if (isNotExcludedUrl(message.page_url)) {
+    if (isValidUrl(message.page_url) && isNotExcludedUrl(message.page_url)) {
       let page_url = get_clean_url(message.page_url)
       let silent = message.silent || false
       let options = (message.options && (message.options !== null)) ? message.options : {}
@@ -452,7 +452,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   }
   else if (message.message === 'openurl') {
     // open URL in new tab or window depending on setting
-    if (isNotExcludedUrl(message.page_url)) {
+    if (isValidUrl(message.page_url) && isNotExcludedUrl(message.page_url)) {
       let page_url = get_clean_url(message.page_url)
       let open_url = message.wayback_url + page_url
       URLopener(open_url, page_url, true)

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -297,11 +297,9 @@ function saveNextInQueue() {
 // Send a Save message to background.js.
 function saveTheURL(url) {
   chrome.runtime.sendMessage({
-    message: 'openurl',
-    wayback_url: hostURL + 'save/',
-    page_url: get_clean_url(url),
+    message: 'saveurl',
+    page_url: url,
     options: saveOptions,
-    method: 'save',
     silent: true
   }, () => {
     if (chrome.runtime.lastError) { /* skip */ }

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -1,7 +1,7 @@
 // bulk-save.js
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, isValidUrl, makeValidURL, cropPrefix, hostURL, dateToTimestamp */
+/*   global isNotExcludedUrl, isValidUrl, makeValidURL, cropPrefix, dateToTimestamp */
 
 // max concurrent saves supported by SPN
 // -1 allows SPN button to work at same time

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -1,7 +1,7 @@
 // bulk-save.js
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, isValidUrl, makeValidURL, cropPrefix, hostURL, get_clean_url, dateToTimestamp */
+/*   global isNotExcludedUrl, isValidUrl, makeValidURL, cropPrefix, hostURL, dateToTimestamp */
 
 // max concurrent saves supported by SPN
 // -1 allows SPN button to work at same time

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -62,11 +62,9 @@ function doSaveNow() {
       options['capture_screenshot'] = 1
     }
     chrome.runtime.sendMessage({
-      message: 'openurl',
-      wayback_url: hostURL + 'save/',
+      message: 'saveurl',
       page_url: url,
       options: options,
-      method: 'save',
       atab: tabs[0]
     }, () => {
       if (chrome.runtime.lastError) { /* skip */ }

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -192,36 +192,43 @@ function social_share(eventObj) {
   }
   // Share wayback link to the most recent snapshot of URL at the time this is called.
   let url = searchValue || activeTabURL
-  let timestamp = dateToTimestamp(new Date())
-  let wayback_url = 'https://web.archive.org/web/' + timestamp + '/'
-  let sharing_url = wayback_url + get_clean_url(url)
+  let clean_url = get_clean_url(url)
+  if (isValidUrl(clean_url)) {
+    let timestamp = dateToTimestamp(new Date())
+    let wayback_url = 'https://web.archive.org/web/' + timestamp + '/'
+    let sharing_url = wayback_url + clean_url
 
-  // Latest Social Share URLs: https://github.com/bradvin/social-share-urls
-  if (id.includes('facebook-share-btn')) {
-    openByWindowSetting('https://www.facebook.com/sharer.php?u=' + fixedEncodeURIComponent(sharing_url))
-  } else if (id.includes('twitter-share-btn')) {
-    openByWindowSetting('https://twitter.com/intent/tweet?url=' + fixedEncodeURIComponent(sharing_url))
-  } else if (id.includes('linkedin-share-btn')) {
-    openByWindowSetting('https://www.linkedin.com/sharing/share-offsite/?url=' + fixedEncodeURIComponent(sharing_url))
-  } else if (id.includes('copy-link-btn') && navigator.clipboard) {
-    navigator.clipboard.writeText(sharing_url).then(() => {
-      let copiedMsg = $('#link-copied-msg')
-      copiedMsg.text('Copied to Clipboard').fadeIn('fast')
-      setTimeout(() => {
-        copiedMsg.fadeOut('fast')
-      }, 1500)
-    }).catch(err => {
-      console.log('Not copied to clipboard: ', err)
-    })
+    // Latest Social Share URLs: https://github.com/bradvin/social-share-urls
+    if (id.includes('facebook-share-btn')) {
+      openByWindowSetting('https://www.facebook.com/sharer.php?u=' + fixedEncodeURIComponent(sharing_url))
+    } else if (id.includes('twitter-share-btn')) {
+      openByWindowSetting('https://twitter.com/intent/tweet?url=' + fixedEncodeURIComponent(sharing_url))
+    } else if (id.includes('linkedin-share-btn')) {
+      openByWindowSetting('https://www.linkedin.com/sharing/share-offsite/?url=' + fixedEncodeURIComponent(sharing_url))
+    } else if (id.includes('copy-link-btn') && navigator.clipboard) {
+      navigator.clipboard.writeText(sharing_url).then(() => {
+        let copiedMsg = $('#link-copied-msg')
+        copiedMsg.text('Copied to Clipboard').fadeIn('fast')
+        setTimeout(() => {
+          copiedMsg.fadeOut('fast')
+        }, 1500)
+      }).catch(err => {
+        console.log('Not copied to clipboard: ', err)
+      })
+    }
   }
 }
 
 function searchTweet() {
   if (activeTabURL) {
     let url = searchValue || get_clean_url(activeTabURL)
-    if (url.slice(-1) === '/') url = url.substring(0, url.length - 1)
-    let open_url = 'https://twitter.com/search?q=' + fixedEncodeURIComponent(url)
-    openByWindowSetting(open_url)
+    if (isValidUrl(url)) {
+      if (url.slice(-1) === '/') {
+        url = url.substring(0, url.length - 1)
+      }
+      let open_url = 'https://twitter.com/search?q=' + fixedEncodeURIComponent(url)
+      openByWindowSetting(open_url)
+    }
   }
 }
 
@@ -356,7 +363,9 @@ function about_support() {
 function sitemap() {
   if (activeTabURL) {
     let url = searchValue || get_clean_url(activeTabURL)
-    openByWindowSetting('https://web.archive.org/web/sitemap/' + url)
+    if (isValidUrl(url)) {
+      openByWindowSetting('https://web.archive.org/web/sitemap/' + url)
+    }
   }
 }
 

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -500,7 +500,6 @@ function setupWikiButtons() {
 function setupFactCheck() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (isNotExcludedUrl(tabs[0].url)) {
-      const url = getCleanUrl(tabs[0].url)
       chrome.storage.local.get(['fact_check_setting'], (settings) => {
         if (settings && settings.fact_check_setting) {
           chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -1,7 +1,7 @@
 // popup.js
 
 // from 'utils.js'
-/*   global isArchiveUrl, isValidUrl, makeValidURL, isNotExcludedUrl, get_clean_url, openByWindowSetting, hostURL */
+/*   global isArchiveUrl, isValidUrl, makeValidURL, isNotExcludedUrl, getCleanUrl, openByWindowSetting, hostURL */
 /*   global feedbackURL, newshosts, dateToTimestamp, timestampToDate, viewableTimestamp, searchValue, fixedEncodeURIComponent */
 /*   global attachTooltip */
 
@@ -50,7 +50,7 @@ function setupSettingsTabTip() {
 
 function doSaveNow() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    let url = searchValue || get_clean_url(tabs[0].url)
+    let url = searchValue || getCleanUrl(tabs[0].url)
     let options = { 'capture_all': 1 }
     if ($('#chk-outlinks').prop('checked') === true) {
       options['capture_outlinks'] = 1
@@ -144,7 +144,7 @@ function checkAuthentication(callback) {
 
 function recent_capture() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/2/',
@@ -158,7 +158,7 @@ function recent_capture() {
 
 function first_capture() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/0/',
@@ -172,7 +172,7 @@ function first_capture() {
 
 function view_all() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     chrome.runtime.sendMessage({
       message: 'openurl',
       wayback_url: 'https://web.archive.org/web/*/',
@@ -192,7 +192,7 @@ function social_share(eventObj) {
   }
   // Share wayback link to the most recent snapshot of URL at the time this is called.
   let url = searchValue || activeTabURL
-  let clean_url = get_clean_url(url)
+  let clean_url = getCleanUrl(url)
   if (isValidUrl(clean_url)) {
     let timestamp = dateToTimestamp(new Date())
     let wayback_url = 'https://web.archive.org/web/' + timestamp + '/'
@@ -221,7 +221,7 @@ function social_share(eventObj) {
 
 function searchTweet() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     if (isValidUrl(url)) {
       if (url.slice(-1) === '/') {
         url = url.substring(0, url.length - 1)
@@ -254,7 +254,7 @@ function setupSearchBox() {
   search_box.addEventListener('keyup', (e) => {
     // exclude UP and DOWN keys from keyup event
     if (!(e.keyCode === 38 || e.which === 38 || e.keyCode === 40 || e.which === 40) && (search_box.value.length >= 0) && isNotExcludedUrl(search_box.value)) {
-      searchValue = get_clean_url(makeValidURL(search_box.value))
+      searchValue = getCleanUrl(makeValidURL(search_box.value))
       // use searchValue if it is valid, else update UI
       searchValue ? useSearchBox() : $('#using-search-msg').hide()
     }
@@ -317,7 +317,7 @@ function display_list(key_word) {
         $('#suggestion-box').append(
           $('<div>').attr('role', 'button').text(data.hosts[i].display_name).click((event) => {
             document.getElementById('search-input').value = event.target.innerHTML
-            searchValue = get_clean_url(makeValidURL(event.target.innerHTML))
+            searchValue = getCleanUrl(makeValidURL(event.target.innerHTML))
             if (searchValue) { useSearchBox() }
           })
         )
@@ -362,7 +362,7 @@ function about_support() {
 
 function sitemap() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     if (isValidUrl(url)) {
       openByWindowSetting('https://web.archive.org/web/sitemap/' + url)
     }
@@ -385,7 +385,7 @@ function show_login_page() {
 // not used
 function show_all_screens() {
   if (activeTabURL) {
-    let url = searchValue || get_clean_url(activeTabURL)
+    let url = searchValue || getCleanUrl(activeTabURL)
     chrome.runtime.sendMessage({ message: 'showall', url: url }, () => {
       if (chrome.runtime.lastError) { /* skip */ }
     })
@@ -500,7 +500,7 @@ function setupWikiButtons() {
 function setupFactCheck() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
     if (isNotExcludedUrl(tabs[0].url)) {
-      const url = get_clean_url(tabs[0].url)
+      const url = getCleanUrl(tabs[0].url)
       chrome.storage.local.get(['fact_check_setting'], (settings) => {
         if (settings && settings.fact_check_setting) {
           chrome.runtime.sendMessage({ message: 'getToolbarState', atab: tabs[0] }, (result) => {
@@ -521,7 +521,7 @@ function setupFactCheck() {
 function showContext(eventObj) {
   let id = eventObj.target.getAttribute('id')
   if (activeTabURL) {
-    const url = searchValue || get_clean_url(activeTabURL)
+    const url = searchValue || getCleanUrl(activeTabURL)
     if (isValidUrl(url)) {
       if (id.includes('fact-check-btn')) {
         const factCheckUrl = chrome.runtime.getURL('fact-check.html') + '?url=' + url

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -276,9 +276,11 @@ function remove_wbm(url) {
 
 // Function to clean the URL if the user is on 'web.archive.org'
 function get_clean_url(url) {
+  console.log(`get_clean_url: ${url}`) // DEBUG
   if (url && url.includes('web.archive.org')) {
     url = remove_wbm(url)
   }
+  console.log(`returns: ${url}`) // DEBUG
   return url
 }
 

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -274,18 +274,12 @@ function remove_wbm(url) {
   return remove_port(new_url)
 }
 
-function getUrlFromExtensionPage(url) {
-  const url_param = new URL(url)
-  return url_param.searchParams.get('url')
-}
-
 /**
 * Extracts URL from web.archive.org or extension page, otherwise the url passed in.
 * @param url {string}
 * @return {string}
 */
-function get_clean_url(url) {
-  console.log(`get_clean_url: ${url}`) // DEBUG
+function getCleanUrl(url) {
   let rurl = url || ''
   if (rurl.includes('extension:')) {
     // return url param from extension page
@@ -295,7 +289,6 @@ function get_clean_url(url) {
     // return url from archive.org page
     rurl = remove_wbm(url)
   }
-  console.log(`returns: ${rurl}`) // DEBUG
   return rurl
 }
 
@@ -549,7 +542,7 @@ if (typeof module !== 'undefined') {
     makeValidURL,
     cropPrefix,
     isNotExcludedUrl,
-    get_clean_url,
+    getCleanUrl,
     wmAvailabilityCheck,
     openByWindowSetting,
     sleep,

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -274,14 +274,29 @@ function remove_wbm(url) {
   return remove_port(new_url)
 }
 
-// Function to clean the URL if the user is on 'web.archive.org'
+function getUrlFromExtensionPage(url) {
+  const url_param = new URL(url)
+  return url_param.searchParams.get('url')
+}
+
+/**
+* Extracts URL from web.archive.org or extension page, otherwise the url passed in.
+* @param url {string}
+* @return {string}
+*/
 function get_clean_url(url) {
   console.log(`get_clean_url: ${url}`) // DEBUG
-  if (url && url.includes('web.archive.org')) {
-    url = remove_wbm(url)
+  let rurl = url || ''
+  if (rurl.includes('extension:')) {
+    // return url param from extension page
+    const url_param = new URL(url)
+    rurl = url_param.searchParams.get('url')
+  } else if (rurl.includes('web.archive.org')) {
+    // return url from archive.org page
+    rurl = remove_wbm(url)
   }
-  console.log(`returns: ${url}`) // DEBUG
-  return url
+  console.log(`returns: ${rurl}`) // DEBUG
+  return rurl
 }
 
 /**


### PR DESCRIPTION
The involved redefining get_clean_url() to return URLs extracted from Extension pages in addition to web.archive.org pages. Renamed this function to getCleanUrl().

Changed the 'openurl' message in background.js and moved Save Page Now to it's own 'saveurl' message.
