### PR TITLE
Bulk Save Limits feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-machine-webextension",
-  "version": "2.999.8",
+  "version": "2.999.9",
   "description": "A browser extension that interfaces with the internet archive",
   "main": "index.js",
   "directories": {

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.8;
+				MARKETING_VERSION = 2.999.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -496,7 +496,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.8;
+				MARKETING_VERSION = 2.999.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -520,7 +520,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.8;
+				MARKETING_VERSION = 2.999.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -543,7 +543,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.8;
+				MARKETING_VERSION = 2.999.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/bulk-save.html
+++ b/webextension/bulk-save.html
@@ -15,10 +15,10 @@
     <div class="header-container">
       <img src="images/app-icon/app-icon128.png" alt="Internet Archive icon" class="ia-logo">
       <h2 id="main-title">Bulk Save</h2>
-      <p id="main-info">Enter a list of URLs below or import from your bookmarks.</p>
-      <p id="error-msg"></p>
-      <p id="empty-list-err">Looks like you haven't added any URLs. Please add some URLs and try again.</p>
-      <p id="not-logged-in">Looks like you aren't logged in. Please log in and try again.</p>
+      <p id="main-info"></p>
+      <p id="error-msg" class="error-color"></p>
+      <p id="empty-list-err" class="error-color">Looks like you haven't added any URLs. Please add some URLs and try again.</p>
+      <p id="not-logged-in" class="error-color">Looks like you aren't logged in. Please log in and try again.</p>
     </div>
 
     <div class="outer-container">
@@ -29,6 +29,7 @@
           <button class="btn btn-auto btn-dark-gray" id="add-url-btn">Add URLs</button>
           <button class="btn btn-auto btn-dark-gray" id="import-bookmarks-btn">Import All Bookmarks</button>
           <button class="btn btn-auto btn-dark-gray" id="clear-all-btn">Clear All</button>
+          <p id="limit-count-info"></p>
         </div>
       </div>
 

--- a/webextension/css/bulk-save.css
+++ b/webextension/css/bulk-save.css
@@ -22,9 +22,12 @@ p {
     display: contents;
 }
 
-#empty-list-err, #not-logged-in {
+.error-color {
     color: #733;
     font-weight: 700;
+}
+
+#empty-list-err, #not-logged-in {
     display: none;
 }
 
@@ -138,6 +141,12 @@ p {
     flex: 2;
 }
 
+#limit-count-info {
+    margin: 0;
+    flex: 2;
+    text-align: right;
+}
+
 #add-url-area {
     flex: 2;
     width: 100%;
@@ -244,7 +253,7 @@ p {
         border: 1px solid #555;
     }
 
-    #empty-list-err, #not-logged-in {
+    .error-color {
         color: #f66;
     }
 

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "2.999.8",
+  "version": "2.999.9",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/bulk-save.js
+++ b/webextension/scripts/bulk-save.js
@@ -370,6 +370,28 @@ function updateLimitCount() {
   }
 }
 
+/**
+ * Fetches Limit Count from API & updates bulkSaveLimit.
+ * expects API to return: { "bulk-save-max": 100 }
+ * @return Promise
+ */
+function fetchLimitCount() {
+  // may need a random number added to url avoid caching?
+  const url = '' // TODO: enter URL of API here
+  const promise = fetch(url, {
+    method: 'GET',
+    headers: { 'Content-Type': 'application/json' }
+  })
+  .then(response => response.json())
+  .then(data => {
+    const num = data['bulk-save-max']
+    if (typeof num === 'number') {
+      bulkSaveLimit = num
+    }
+  })
+  return promise
+}
+
 // Update an individual URL item in the list container.
 function processStatus(msg, url, wbUrl) {
   let curl = cropPrefix(url)
@@ -473,4 +495,5 @@ $(function() {
   resetUI()
   initMessageListener()
   updateLimitCount()
+  // fetchLimitCount().then(data => { updateLimitCount() }) // uncomment to fetch limit from API
 })


### PR DESCRIPTION
Limits number of URLs that may be added to list of URLs in Bulk Save. Includes code for fetching this max value from a remote API. (currently disabled as API endpoint still needs to be determined.)

If this value < 0, then remove any limit. If == 0, then inform user that Bulk Save is unavailable.
