### PR TITLE
Add 404 setting options to private_before_default and remove others

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -24,12 +24,6 @@ let WB_API_URL = hostURL + 'wayback/available'
 const SPN_RETRY = 6000
 
 let private_before_default = new Set([
-  'fact-check-setting',
-  'wm-count-setting',
-  'wiki-setting',
-  'amazon-setting',
-  'tvnews-setting',
-  'email-outlinks-setting',
   'not-found-setting'
 ])
 


### PR DESCRIPTION
If someone reload the extension OR install it new, by default the “404 option is checked” in the settings. Then if user is selecting some more options and then if the user is selecting and deselecting private mode, you can see that all other checkboxes are checked. It is not restoring to its previous state.

This PR is a fix to that