### PR TITLE
Removed 'tabs' permission from manifest

### DIFF
--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -30,7 +30,6 @@
       "contextMenus",
       "notifications",
       "storage",
-      "tabs",
       "webRequest",
       "webRequestBlocking",
       "https://archive.org/*",


### PR DESCRIPTION
Everything seems to work fine with 'tabs' permission removed from manifest, since the 'activeTab' permission allows use of tabs. Could use further testing in all 3 browsers.