### PR TITLE
Auto Save Age dropdown in Settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-machine-webextension",
-  "version": "2.999.28",
+  "version": "2.999.29",
   "description": "A browser extension that interfaces with the internet archive",
   "main": "index.js",
   "directories": {

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -455,7 +455,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.28;
+				MARKETING_VERSION = 2.999.29;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -476,7 +476,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.28;
+				MARKETING_VERSION = 2.999.29;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -500,7 +500,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.28;
+				MARKETING_VERSION = 2.999.29;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -523,7 +523,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.28;
+				MARKETING_VERSION = 2.999.29;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -39,33 +39,6 @@
     color: #fff;
 }
 
-
-/* dark mode */
-
-@media (prefers-color-scheme: dark) {
-
-    #setting-page label {
-        font-weight: 500;
-    }
-
-    #view-setting-text {
-        font-weight: 500;
-    }
-
-    .setting-switch {
-        border: 1px solid #666;
-    }
-    .setting-switch:hover {
-        background-color: #444;
-    }
-
-    .btn-docs {
-        background-color: #888;
-        color: #000;
-    }
-
-}
-
 /* navgation bar */
 
 ul.setting-nav {
@@ -83,6 +56,9 @@ ul.setting-nav li {
 
 #auto-archive-age {
     border-style: none;
+    border-radius: 4px;
+    padding: 1px;
+    background-color: #ddd;
 }
 
 #view-setting {
@@ -129,4 +105,34 @@ label[for=tagcloud] {
 
 .setting-tip {
     width: 100px;
+}
+
+/* dark mode */
+
+@media (prefers-color-scheme: dark) {
+
+    #setting-page label {
+        font-weight: 500;
+    }
+
+    #auto-archive-age {
+        background-color: #3c3c3c;
+    }
+
+    #view-setting-text {
+        font-weight: 500;
+    }
+
+    .setting-switch {
+        border: 1px solid #666;
+    }
+    .setting-switch:hover {
+        background-color: #444;
+    }
+
+    .btn-docs {
+        background-color: #888;
+        color: #000;
+    }
+
 }

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -81,6 +81,10 @@ ul.setting-nav li {
 
 /* options */
 
+#auto-archive-age {
+    border-style: none;
+}
+
 #view-setting {
     text-align: center !important;
 }

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -163,7 +163,18 @@
         <input type="checkbox" name="private-include" class="private" id="auto-archive-setting">
         <div class="setting-text-box">
           <span class="toggle">Auto Save Page</span>
-          <img src="images/toolbar/toolbar-icon-S32.png" alt="S" class="toolbar-icon">
+          <img src="images/toolbar/toolbar-icon-S32.png" alt="S" class="toolbar-icon"><br>
+          <div style="margin-top: 0.5em">
+            if not archived:<br>
+            <select id="auto-archive-age">
+              <option value="99999" selected>previously</option>
+              <option value="365">within past year</option>
+              <option value="90">within 90 days</option>
+              <option value="30">within 30 days</option>
+              <option value="7">within 7 days</option>
+              <option value="1">within 24 hours</option>
+            </select>
+          </div>
         </div>
       </label>
       <label class="setting-switch" for="email-outlinks-setting">

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "2.999.28",
+  "version": "2.999.29",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -6,7 +6,7 @@
 // from 'utils.js'
 /*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
 /*   global initDefaultOptions, afterAcceptOptions, badgeCountText, getWaybackCount, newshosts, dateToTimestamp, fixedEncodeURIComponent, checkLastError */
-/*   global hostHeaders, gCustomUserAgent */
+/*   global hostHeaders, gCustomUserAgent, timestampToDate */
 
 // Used to store the statuscode of the if it is a httpFailCodes
 let gStatusCode = ''
@@ -572,10 +572,20 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
   if (!isNotExcludedUrl(tab.url)) { return }
   if (info.status === 'complete') {
     updateWaybackCountBadge(tab, tab.url)
-    chrome.storage.local.get(['auto_archive_setting', 'fact_check_setting'], (settings) => {
+    chrome.storage.local.get(['auto_archive_setting', 'auto_archive_age', 'fact_check_setting'], (settings) => {
       // auto save page
       if (settings && settings.auto_archive_setting) {
-        auto_save(tab, tab.url)
+        if (settings.auto_archive_age) {
+          // auto_archive_age is an int of days before now
+          const days = parseInt(settings.auto_archive_age, 10)
+          if (!isNaN(days)) {
+            const milisecs = days * 24 * 60 * 60 * 1000
+            const beforeDate = new Date(Date.now() - milisecs)
+            auto_save(tab, tab.url, beforeDate)
+          }
+        } else {
+          auto_save(tab, tab.url)
+        }
       }
       // fact check
       /*
@@ -677,12 +687,17 @@ chrome.tabs.onActivated.addListener((info) => {
   })
 })
 
-function auto_save(atab, url) {
+function auto_save(atab, url, beforeDate) {
   if (isValidUrl(url) && isNotExcludedUrl(url)) {
     wmAvailabilityCheck(url,
-      () => {
-        // check if page is now in archive after auto-saved
-        // (don't do anything)
+      (wayback_url, url, timestamp) => {
+        // save if timestamp from availability API is older than beforeDate
+        if (beforeDate) {
+          const checkDate = timestampToDate(timestamp)
+          if ((checkDate.getTime() < beforeDate.getTime()) && !getToolbarState(atab).has('S')) {
+            savePageNow(atab, url, true)
+          }
+        }
       },
       () => {
         // set auto-save toolbar icon if page doesn't exist, then save it

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -16,10 +16,10 @@ $(function() {
   $('#view-setting').children('input,label').click((e) => { e.stopPropagation() })
   $('input[type=checkbox],input[type=radio]').change(saveOptions)
   $('#auto-archive-age').change((e) => {
-    $('#auto-archive-setting').prop('checked', true)
+    $('#auto-archive-setting').prop('checked', true).addClass('selected-prior')
     saveOptions()
     e.target.blur()
-    // FIXME: selecting Private Mode isn't clearing checkbox
+    validatePrivateMode()
   })
   $('.back-btn').click(goBack)
   switchSetting()

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -18,6 +18,7 @@ $(function() {
   $('#auto-archive-age').change((e) => {
     $('#auto-archive-setting').prop('checked', true)
     saveOptions()
+    e.target.blur()
     // FIXME: selecting Private Mode isn't clearing checkbox
   })
   $('.back-btn').click(goBack)

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -89,7 +89,7 @@ function saveOptions() {
   chrome.runtime.sendMessage({ message: 'clearResource', settings: settings })
 }
 
-function validatePrivateMode(event) {
+function validatePrivateMode() {
   let checkboxes = $('[name="private-include"]')
   let checkedCount = checkboxes.filter((_index, item) => item.checked === true).length
   if (checkedCount > 0) {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -15,6 +15,11 @@ $(function() {
   $('#view-setting').click(switchTabWindow)
   $('#view-setting').children('input,label').click((e) => { e.stopPropagation() })
   $('input[type=checkbox],input[type=radio]').change(saveOptions)
+  $('#auto-archive-age').change((e) => {
+    $('#auto-archive-setting').prop('checked', true)
+    saveOptions()
+    // FIXME: selecting Private Mode isn't clearing checkbox
+  })
   $('.back-btn').click(goBack)
   switchSetting()
   addDocs()
@@ -38,6 +43,7 @@ function restoreOptions(items) {
   $('#tvnews-setting').prop('checked', items.tvnews_setting)
   /* Second Panel */
   $('#auto-archive-setting').prop('checked', items.auto_archive_setting)
+  $('#auto-archive-age').val(items.auto_archive_age || '99999')
   $('#email-outlinks-setting').prop('checked', items.email_outlinks_setting)
   $('#resource-list-setting').prop('checked', items.resource_list_setting)
   $(`input[name=view-setting-input][value=${items.view_setting}]`).prop('checked', true)
@@ -62,6 +68,7 @@ function saveOptions() {
     tvnews_setting: $('#tvnews-setting').prop('checked'),
     /* Second Panel */
     auto_archive_setting: $('#auto-archive-setting').prop('checked'),
+    auto_archive_age: $('#auto-archive-age').val(),
     email_outlinks_setting: $('#email-outlinks-setting').prop('checked'),
     resource_list_setting: $('#resource-list-setting').prop('checked'),
     view_setting: $('input[name=view-setting-input]:checked').val()

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -550,6 +550,7 @@ function initDefaultOptions () {
     amazon_setting: false,
     tvnews_setting: false,
     auto_archive_setting: false,
+    auto_archive_age: '99999',
     fact_check_setting: false,
     /* General */
     resource_list_setting: false,


### PR DESCRIPTION
Implements #673 

This enhances the Auto Save Page feature by adding a dropdown list to Settings. Now instead of only auto-saving if a website has never been archived before, the user can specify an age such as 1 year, 90 days, or as soon as 24 hours. This would activate Auto Save if the latest archive is at least that age or older.

<img width="217" alt="auto-save-age-screenshot" src="https://user-images.githubusercontent.com/604259/144516073-3d6bc848-cd37-43fe-b170-3489528ead97.png">

Known Issue: Setting Private Mode may not correctly clear Auto Save. This will be fixed in a future PR.
