### PR TITLE
Add 522 to the error code dict

### DIFF
--- a/webextension/scripts/archive.js
+++ b/webextension/scripts/archive.js
@@ -16,6 +16,7 @@ const ERROR_CODE_DIC = {
   509: '509 Bandwidth Limit Exceeded',
   520: '520 Unknown Error',
   521: '521 Server Is Down',
+  522: '522 Connection timed out',
   523: '523 Unreachable Origin',
   524: '524 Timout Occurred',
   525: '525 SSL Handshake Failed',


### PR DESCRIPTION
For some urls like https://www.projet-voltaire.fr/regles-orthographe/va-ou-vas/ gives the archived version notice but shows "undefined" at the top of the notice. It is because 522 status code is not there in the `ERROR_CODE_DIC` in the code.
This is a fix for it.