### PR TITLE
Tweak size of popup windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wayback-machine-webextension",
-  "version": "2.999.35",
+  "version": "2.999.36",
   "description": "A browser extension that interfaces with the internet archive",
   "main": "index.js",
   "directories": {

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -451,7 +451,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.35;
+				MARKETING_VERSION = 2.999.36;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -472,7 +472,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.35;
+				MARKETING_VERSION = 2.999.36;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -496,7 +496,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.35;
+				MARKETING_VERSION = 2.999.36;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -519,7 +519,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 2.999.35;
+				MARKETING_VERSION = 2.999.36;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "2.999.35",
+  "version": "2.999.36",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -539,7 +539,6 @@ function opener(url, option, callback) {
       w = Math.floor(w * 0.9)
       h = Math.floor(h * 0.9)
     }
-    console.log(`final size: ${w} x ${h}`)
     chrome.windows.create({ url: url, width: w, height: h, type: 'popup' }, (window) => {
       if (callback) { callback(window.tabs[0].id) }
     })

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -528,17 +528,19 @@ function opener(url, option, callback) {
       if (callback) { callback(tab.id) }
     })
   } else {
-    let w, h
-    if (screen.width > screen.height) {
+    let w = window.screen.availWidth, h = window.screen.availHeight
+    if (w > h) {
       // landscape screen
-      w = Math.floor(screen.width * 0.666)
+      const maxW = 1200
+      w = Math.floor(((w > maxW) ? maxW : w) * 0.666)
       h = Math.floor(w * 0.75)
     } else {
       // portrait screen (likely mobile)
-      w = Math.floor(screen.width * 0.9)
-      h = Math.floor(screen.height * 0.9)
+      w = Math.floor(w * 0.9)
+      h = Math.floor(h * 0.9)
     }
-    chrome.windows.create({ url: url, width: w, height: h, top: 0, left: 0, type: 'popup' }, (window) => {
+    console.log(`final size: ${w} x ${h}`)
+    chrome.windows.create({ url: url, width: w, height: h, type: 'popup' }, (window) => {
       if (callback) { callback(window.tabs[0].id) }
     })
   }


### PR DESCRIPTION
Noticing an issue under Firefox and multiple monitors, popup windows wouldn't size correctly. They'd show up on the 2nd screen, size too large for the screen, which Firefox would then resize to a really small window. This PR fixes that issue and defines a max width.