### PR TITLE
Fix for auto-save not activating

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -6,7 +6,7 @@
 // from 'utils.js'
 /*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
 /*   global initDefaultOptions, afterAcceptOptions, badgeCountText, getWaybackCount, newshosts, dateToTimestamp, fixedEncodeURIComponent, checkLastError */
-/*   global hostHeaders, gCustomUserAgent, timestampToDate, isBadgeOnTop, isUrlInList, getTabKey, saveTabData, readTabData */
+/*   global hostHeaders, gCustomUserAgent, timestampToDate, isBadgeOnTop, isUrlInList, getTabKey, saveTabData, readTabData, initAutoExcludeList */
 
 // Used to store the statuscode of the if it is a httpFailCodes
 let gStatusCode = 0
@@ -369,6 +369,7 @@ chrome.runtime.onStartup.addListener((details) => {
 // Runs when extension first installed or updated, or browser updated.
 chrome.runtime.onInstalled.addListener((details) => {
   initDefaultOptions()
+  initAutoExcludeList()
   chrome.storage.local.get({ agreement: false }, (settings) => {
     if (settings && settings.agreement) {
       afterAcceptOptions()
@@ -761,7 +762,8 @@ chrome.tabs.onActivated.addListener((info) => {
 function autoSave(atab, url, beforeDate) {
   if (isValidUrl(url) && isNotExcludedUrl(url) && !getToolbarState(atab).has('S')) {
     chrome.storage.local.get(['auto_exclude_list'], (items) => {
-      if (('auto_exclude_list' in items) && items.auto_exclude_list && !isUrlInList(url, items.auto_exclude_list)) {
+      if (!('auto_exclude_list' in items) ||
+       (('auto_exclude_list' in items) && items.auto_exclude_list && !isUrlInList(url, items.auto_exclude_list))) {
         wmAvailabilityCheck(url,
           (wayback_url, url, timestamp) => {
             // save if timestamp from availability API is older than beforeDate

--- a/webextension/scripts/exclude-list.js
+++ b/webextension/scripts/exclude-list.js
@@ -1,16 +1,7 @@
 // exclude-list.js
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, cropPrefix */
-
-const defaultExcludeList = [
-  'archive.org*',
-  'web.archive.org*',
-  'google.com*',
-  '*.google.com*',
-  'mail.yahoo.com*',
-  'duckduckgo.com/?q=*'
-]
+/*   global defaultAutoExcludeList, isNotExcludedUrl, cropPrefix */
 
 // Removes focus outline on mouse click, while keeping during keyboard use.
 function clearFocus() {
@@ -34,7 +25,7 @@ function loadExcludeList() {
       fillTextArea(items.auto_exclude_list)
     } else {
       // use a default list of excluded URLs
-      fillTextArea(defaultExcludeList)
+      fillTextArea(defaultAutoExcludeList)
     }
   })
 }
@@ -53,11 +44,11 @@ function saveExcludeList() {
   }
   // save the modified list
   const exlist = Array.from(urlSet)
-  chrome.storage.local.set({ 'auto_exclude_list': exlist }, () => {})
+  chrome.storage.local.set({ 'auto_exclude_list': exlist })
 }
 
 function resetExcludeList() {
-  fillTextArea(defaultExcludeList)
+  fillTextArea(defaultAutoExcludeList)
 }
 
 function clearExcludeList() {

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -3,6 +3,16 @@
 // from 'test/setup.js'
 /*   global isInTestEnv */
 
+// default exclude list for auto-save
+const defaultAutoExcludeList = [
+  'archive.org*',
+  'web.archive.org*',
+  'google.com*',
+  '*.google.com*',
+  'mail.yahoo.com*',
+  'duckduckgo.com/?q=*'
+]
+
 // list of excluded URLs
 const excluded_urls = [
   'localhost',
@@ -633,6 +643,15 @@ function attachTooltip (anchor, tooltip, pos = 'right', time = 200) {
   })
 }
 
+// Saves the defaultAutoExcludeList[] to storage if 'auto_exclude_list' hasn't been set.
+function initAutoExcludeList() {
+  chrome.storage.local.get(['auto_exclude_list'], (items) => {
+    if (('auto_exclude_list' in items) === false) {
+      chrome.storage.local.set({ 'auto_exclude_list': defaultAutoExcludeList })
+    }
+  })
+}
+
 // Default Settings prior to accepting terms.
 function initDefaultOptions () {
   chrome.storage.local.set({
@@ -713,6 +732,7 @@ if (typeof module !== 'undefined') {
     timestampToDate,
     dateToTimestamp,
     viewableTimestamp,
+    initAutoExcludeList,
     initDefaultOptions,
     afterAcceptOptions,
     feedbackURL,


### PR DESCRIPTION
Fixes #856

Initializes the Auto-save Exclude List to fix a bug where auto-save wouldn't activate without user first opening the Exclude List window. Tested on Chrome, Firefox, Safari.