### PR TITLE
Save Without Login using a form redirect

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.12;
+				MARKETING_VERSION = 3.0.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.12;
+				MARKETING_VERSION = 3.0.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.12;
+				MARKETING_VERSION = 3.0.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.12;
+				MARKETING_VERSION = 3.0.0.13;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.0.0.12",
+  "version": "3.0.0.13",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -72,8 +72,10 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
   if (isValidUrl(pageUrl) && isNotExcludedUrl(pageUrl)) {
 
     if (loggedInFlag === false) {
-      // Use anonymous SPN GET method by opening a new tab and skipping status updates within extension.
-      openByWindowSetting('https://web.archive.org/save/' + pageUrl)
+      // Use anonymous SPN POST
+      // opens a new tab that submits a POST form to open page with URL prefilled.
+      const redirectUrl = chrome.runtime.getURL('spn-redirect.html') + '?url=' + pageUrl
+      openByWindowSetting(redirectUrl)
       return
     }
 

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -94,13 +94,19 @@ function doSaveNow() {
     if ($('#chk-screenshot').prop('checked') === true) {
       options['capture_screenshot'] = 1
     }
+
     chrome.runtime.sendMessage({
       message: 'saveurl',
       page_url: url,
       options: options,
       atab: activeTab
     }, checkLastError)
-    showSaving()
+
+    // animate SPN button only if logged in
+    checkAuthentication((result) => {
+      checkLastError()
+      if (result && result.auth_check) { showSaving() }
+    })
   }
 }
 

--- a/webextension/scripts/spn-redirect.js
+++ b/webextension/scripts/spn-redirect.js
@@ -1,0 +1,7 @@
+// spn-redirect.js
+
+// submits a POST form to open SPN Wayback Machine website with url prefilled.
+let params = (new URL(window.location)).searchParams;
+let url = params.get('url');
+document.getElementById('url-preload').value = url
+document.getElementById('save-form').submit()

--- a/webextension/scripts/spn-redirect.js
+++ b/webextension/scripts/spn-redirect.js
@@ -1,7 +1,7 @@
 // spn-redirect.js
 
 // submits a POST form to open SPN Wayback Machine website with url prefilled.
-let params = (new URL(window.location)).searchParams;
-let url = params.get('url');
+let params = (new URL(window.location)).searchParams
+let url = params.get('url')
 document.getElementById('url-preload').value = url
 document.getElementById('save-form').submit()

--- a/webextension/spn-redirect.html
+++ b/webextension/spn-redirect.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+  <meta content="utf-8" http-equiv="encoding">
+  <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
+  <link rel="stylesheet" type="text/css" href="css/common.css">
+  <link rel="icon" type="image/png" href="images/toolbar/toolbar-icon-archive32.png">
+  <title>Redirecting...</title>
+</head>
+<body class="body-container">
+  <div class="text-center" style="margin-top: 5em">
+    <img src="images/wayback-light.png" alt="Wayback Machine logo" style="width: 250px; margin: 2em">
+    <h4 id="main-title">Save Page Now</h4>
+  </div>
+
+  <form id="save-form" method="POST" action="https://web.archive.org/save" style="display:none">
+    <input type="hidden" id="url-preload" name="url_preload">
+  </form>
+  <script src="scripts/spn-redirect.js"></script>
+</body>
+</html>

--- a/webextension/spn-redirect.html
+++ b/webextension/spn-redirect.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="icon" type="image/png" href="images/toolbar/toolbar-icon-archive32.png">
-  <title>Redirecting...</title>
+  <title>Loading...</title>
 </head>
 <body class="body-container">
   <div class="text-center" style="margin-top: 5em">

--- a/webextension/spn-redirect.html
+++ b/webextension/spn-redirect.html
@@ -11,7 +11,7 @@
 <body class="body-container">
   <div class="text-center" style="margin-top: 5em">
     <img src="images/wayback-light.png" alt="Wayback Machine logo" style="width: 250px; margin: 2em">
-    <h4 id="main-title">Save Page Now</h4>
+    <h4 id="main-title">Redirecting to Save Page Now...</h4>
   </div>
 
   <form id="save-form" method="POST" action="https://web.archive.org/save" style="display:none">


### PR DESCRIPTION
improving #891
Opens a Wayback Machine webpage to Save Page Now anonymously when SPN button pressed.

Since there's no direct way to POST to a URL inside web extension code, I had to open a temporary internal page to automatically submit a form while passing in the URL to save.