### PR TITLE
Welcome page buttons always visible

### DIFF
--- a/webextension/css/welcome.css
+++ b/webextension/css/welcome.css
@@ -2,26 +2,46 @@
 body {
     font-size: 24px;
     text-align: left;
-    margin-top: 2em;
 }
 
-#header {
-    font-size: 30px;
-    text-align: center;
+h1, h2, h3, h4 {
+    color: inherit;
 }
-
-div#content > h1 {
-    text-align: center;
+h1 {
+    font-size: 22pt;
 }
-
-#content {
-    margin: auto 15vw 10vh 15vw;
+h4 {
+    margin-top: 1em;
+    font-size: 14pt;
 }
 
 p {
     text-align: justify;
 }
 
-h1, h2, h3, h4 {
-  color: inherit;
+.body-container {
+    height: 100vh;
+    margin-top: 1em;
+    padding: 0;
+}
+
+.header-container {
+    text-align: center;
+}
+
+.content-container {
+    margin: 2em 15vw 10vh 15vw;
+    padding-bottom: 5em;
+}
+
+.bottom-container {
+    position: fixed;
+    margin: 0;
+    padding: 0.5em 15vw 0.5em 15vw;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+    background-color: #ddd;
+    border-top: 1px solid #888;
 }

--- a/webextension/welcome.html
+++ b/webextension/welcome.html
@@ -10,18 +10,16 @@
     <title>Welcome to the Internet Archive's Wayback Machine Extension!</title>
   </head>
   <body>
-    <div id="container">
-      <div id="header">
+    <div class="body-container">
+      <div class="header-container">
         <img src="images/wayback-light.png" style="height:150px">
-        <h1 style="margin-top: 0.5em">
+        <h1>
           Welcome to the Internet Archive's<br>
           Wayback Machine Browser Extension
         </h1>
       </div>
-      <div id="content" style="margin-top: 2em">
-        <style>
-          h4 { margin-top: 1em; font-size: 14pt; }
-        </style>
+
+      <div class="content-container">
         <h3>
           The Internet Archive Wayback Machine Browser Extension Privacy Policy
         </h3>
@@ -67,15 +65,17 @@
         <p>
           We retain collected URLs for as long as they provide value to our mission.
         </p>
-        <p style="margin-top: 2em">
-          <button type="submit" name="accept-terms" id="accept-btn" class="btn btn-auto btn-blue">
-            <span>Accept and Enable</span>
-          </button>
-          <button type="submit" name="decline-terms" id="decline-btn" class="btn btn-auto btn-dark-gray">
-            <span>Cancel</span>
-          </button>
-        </p>
       </div>
+
+      <div class="bottom-container">
+        <button type="submit" name="accept-terms" id="accept-btn" class="btn btn-auto btn-blue">
+          <span>Accept and Enable</span>
+        </button>
+        <button type="submit" name="decline-terms" id="decline-btn" class="btn btn-auto btn-dark-gray">
+          <span>Cancel</span>
+        </button>
+      </div>
+
     </div>
 
     <script src="libs/jquery.js"></script>


### PR DESCRIPTION
We noticed that some users missed the Accept button in the Welcome screen, which would show repeatedly since they never clicked on the Accept button before closing the window. This PR places the buttons fixed along the bottom edge so that they're always visible.