### PR TITLE
Clear settings that should be clear when logged out

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.18;
+				MARKETING_VERSION = 3.0.0.19;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.18;
+				MARKETING_VERSION = 3.0.0.19;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.18;
+				MARKETING_VERSION = 3.0.0.19;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.0.0.18;
+				MARKETING_VERSION = 3.0.0.19;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -69,10 +69,10 @@
         </div>
         <div class="chk-frame">
           <label class="chk-options auth-click1" for="chk-outlinks" id="chk-outlinks-label" title="Archive all Outlinked URLs">
-            <span class="auth-icon"><input type="checkbox" class="saved-setting" id="chk-outlinks"></span><span class="auth-dim" id="chk-outlinks-text">Outlinks</span>
+            <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="chk-outlinks"></span><span class="auth-dim" id="chk-outlinks-text">Outlinks</span>
           </label>
           <label class="chk-options auth-click1" for="chk-screenshot" id="chk-screenshot-label" title="Archive a Screenshot (image)">
-            <span class="auth-icon"><input type="checkbox" class="saved-setting" id="chk-screenshot"></span><span class="auth-dim" id="chk-screenshot-text">Screenshot</span>
+            <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="chk-screenshot"></span><span class="auth-dim" id="chk-screenshot-text">Screenshot</span>
           </label>
           <!-- <div class="chk-options" id="chk-login-btn"><span>Log in for options</span></div> -->
         </div>
@@ -222,13 +222,13 @@
         </div>
       </label>
       <label class="setting-switch auth-click2" for="email-outlinks-setting">
-        <span class="auth-icon"><input type="checkbox" class="saved-setting" id="email-outlinks-setting"></span>
+        <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="email-outlinks-setting"></span>
         <div class="setting-text-box">
           <span class="toggle auth-dim">Email Outlinks</span>
         </div>
       </label>
       <label class="setting-switch auth-click2" for="my-archive-setting">
-        <span class="auth-icon"><input type="checkbox" class="saved-setting" id="my-archive-setting"></span>
+        <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="my-archive-setting"></span>
         <div class="setting-text-box">
           <span class="toggle auth-dim">Save To My Web Archive</span>
         </div>

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.0.0.18",
+  "version": "3.0.0.19",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -190,6 +190,9 @@ function loginError() {
 
   // setup messages
   if (activeURL && !isNotExcludedUrl(activeURL)) { showUrlNotSupported(true) }
+
+  // clears settings that should be clear when logged out.
+  $('.clear-on-logout').prop('checked', false).trigger('change')
 }
 
 // Called when logged-in.


### PR DESCRIPTION
Fixes a bug where settings such as "Outlinks" or "Save To My Web Archive", if set while logged in, remain set when logged out.