### PR TITLE
Show features in Same Tab option

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.2;
+				MARKETING_VERSION = 3.1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.2;
+				MARKETING_VERSION = 3.1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.2;
+				MARKETING_VERSION = 3.1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.2;
+				MARKETING_VERSION = 3.1.0.3;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -62,6 +62,10 @@ ul.setting-nav li {
     text-align: center !important;
 }
 
+#view-setting label {
+    margin: 0;
+}
+
 .setting-switch * {
     cursor: pointer;
 }

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -287,10 +287,10 @@
         <div id="view-setting-text">Show Features In</div>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-tab" value="tab">
         <label class="toggle" for="view-setting-tab">New Tab</label>&nbsp;
-        <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-window" value="window">
-        <label class="toggle" for="view-setting-window">Window</label><br>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-replace" value="replace">
-        <label class="toggle" for="view-setting-replace">Replace</label><br>
+        <label class="toggle" for="view-setting-replace">Same Tab</label><br>
+        <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-window" value="window">
+        <label class="toggle" for="view-setting-window">New Window</label><br>
       </div>
     </div>
 

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -286,9 +286,11 @@
       <div class="setting-switch" id="view-setting">
         <div id="view-setting-text">Show Features In</div>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-tab" value="tab">
-        <label class="toggle" for="view-setting-tab">Tab</label>&nbsp;
+        <label class="toggle" for="view-setting-tab">New Tab</label>&nbsp;
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-window" value="window">
-        <label class="toggle" for="view-setting-window">Window</label>
+        <label class="toggle" for="view-setting-window">Window</label><br>
+        <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-replace" value="replace">
+        <label class="toggle" for="view-setting-replace">Replace</label><br>
       </div>
     </div>
 

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.2",
+  "version": "3.1.0.3",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -829,15 +829,6 @@ function enableAfterSaving() {
   $('#chk-screenshot').removeAttr('disabled')
 }
 
-// make the tab/window option in setting page checked according to previous setting
-function setupViewSetting() {
-  chrome.storage.local.get(['view_setting'], (settings) => {
-    if (settings && settings.view_setting) {
-      $(`input[name=tw][value=${settings.view_setting}]`).prop('checked', true)
-    }
-  })
-}
-
 // respond to Save Page Now success
 function setupSaveListener() {
   chrome.runtime.onMessage.addListener(
@@ -891,7 +882,6 @@ $(function() {
   setupLoginState()
   setupWaybackCount()
   setupSaveListener()
-  setupViewSetting()
   setupSettingsTabTip()
   $('.logo-wayback-machine').click(homepage)
   $('#newest-btn').click(openNewestPage)

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -169,9 +169,14 @@ function setupPanelSwitch() {
   })
 }
 
-// Toggles the Tab/Window setting.
+// Cycles the Tab/Window setting.
 function switchTabWindow() {
-  $('input[name=view-setting-input]').not(':checked').prop('checked', true).trigger('change')
+  let idx = 0, inputs = $('input[name=view-setting-input]')
+  for (let i = 0; i < inputs.length; i++) {
+    if (inputs[i].checked) { idx = i }
+  }
+  let j = (idx + 1) % inputs.length // wrap around using mod
+  $(inputs[j]).prop('checked', true).trigger('change')
 }
 
 function setupHelpDocs() {

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -627,6 +627,15 @@ function opener(url, option, callback) {
     chrome.tabs.create({ url: url }, (tab) => {
       if (callback) { callback(tab.id) }
     })
+  } else if (option === 'replace') {
+    // TODO: need to be able to go Back to prior page!
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs && tabs[0]) {
+        chrome.tabs.update(tabs[0].id, { url: url }, (tab) => {
+          if (callback) { callback(tab.id) }
+        })
+      }
+    })
   } else {
     let w = window.screen.availWidth, h = window.screen.availHeight
     if (w > h) {
@@ -634,7 +643,7 @@ function opener(url, option, callback) {
       const maxW = 1200
       w = Math.floor(((w > maxW) ? maxW : w) * 0.666)
       h = Math.floor(w * 0.75)
-    } else {
+    } else { // option === 'window'
       // portrait screen (likely mobile)
       w = Math.floor(w * 0.9)
       h = Math.floor(h * 0.9)

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -628,10 +628,10 @@ function opener(url, option, callback) {
       if (callback) { callback(tab.id) }
     })
   } else if (option === 'replace') {
-    // TODO: need to be able to go Back to prior page!
+    // Back button may not work due to a bug in Chrome, but works fine in Firefox.
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       if (tabs && tabs[0]) {
-        chrome.tabs.update(tabs[0].id, { url: url }, (tab) => {
+        chrome.tabs.update(tabs[0].id, { active: true, url: url }, (tab) => {
           if (callback) { callback(tab.id) }
         })
       }


### PR DESCRIPTION
Implements #896

Adds 'Same Tab' option to Settings:
<img width="217" alt="show-features-in" src="https://user-images.githubusercontent.com/604259/176264412-88e65f1c-787d-496e-ac88-b7e06f6e8a6d.png">

There's a reported bug in Chrome where the browser's Back button won't let the user go back to the prior page after opening a URL when Same Tab option is active. Works fine in Firefox.