### PR TITLE
Manage websites excluded from viewing on the Wayback Machine

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -258,6 +258,9 @@ Test that SPN works on URLs containing percent-encodings: [#279](https://github.
 
 Check above URLs work with Wayback (Oldest, Overview, Newest), Social Links, Copy to Clipboard.
 
+Test that URLs which are excluded from the Wayback Machine don't Auto-Save, buttons disabled, message shows. See issue [#944](https://github.com/internetarchive/wayback-machine-webextension/issues/944) and [PR #951](https://github.com/internetarchive/wayback-machine-webextension/pull/951) for screenshots.
+- Example: https://www.tomshardware.com/
+
 </td>
 </tr>
 

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.3;
+				MARKETING_VERSION = 3.1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.3;
+				MARKETING_VERSION = 3.1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.3;
+				MARKETING_VERSION = 3.1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.3;
+				MARKETING_VERSION = 3.1.0.4;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -83,25 +83,25 @@
       </div>
 
       <div class="btn-flex-block">
-        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim" id="oldest-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim blocked-dim" id="oldest-btn"
           title="Display the earliest archive of a URL">Oldest</button>
-        <button tabindex="0" class="btn-social btn-sm btn-red not-sup-dim" id="overview-btn" title="Display a Calendar of archives">
+        <button tabindex="0" class="btn-social btn-sm btn-red not-sup-dim blocked-dim" id="overview-btn" title="Display a Calendar of archives">
           <img src="images/fa/calendar-alt-regular.svg" alt="Overview">
         </button>
-        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim" id="newest-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim blocked-dim" id="newest-btn"
           title="Display the most recent archive of a URL">Newest</button>
       </div>
 
       <div class="btn-flex-block">
-        <button type="button" class="btn btn-sm btn-equal btn-dark-gray not-sup-dim" id="urls-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-dark-gray not-sup-dim blocked-dim" id="urls-btn"
           title="Show list of URLs captured under the current website">URLs</button>
-        <button type="button" class="btn btn-sm btn-equal btn-dark-gray not-sup-dim" id="collections-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-dark-gray not-sup-dim blocked-dim" id="collections-btn"
           title="Show archived URL by Collection">Collections</button>
         <!-- <button type="button" class="btn btn-sm btn-equal btn-dark-gray" id="bulk-save-btn">Bulk Save</button> -->
       </div>
 
       <div class="btn-flex-block">
-        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim" id="site-map-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim blocked-dim" id="site-map-btn"
           title="Display a Site Map for a site, based on archived URLs in the Wayback Machine">Site Map</button>
         <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim" id="tag-cloud-btn"
           title="Display a Word Cloud based on a site">Word Cloud</button>
@@ -177,19 +177,19 @@
         <div id="link-copied-msg"></div>
       </div>
       <div class="share-block">
-        <button tabindex="0" id="facebook-share-btn" class="btn-social btn-sm btn-facebook not-sup-dim"
+        <button tabindex="0" id="facebook-share-btn" class="btn-social btn-sm btn-facebook not-sup-dim blocked-dim"
           title="Share an archive with Facebook">
           <img src="images/fa/facebook-f-brands.svg" alt="Facebook">
         </button>
-        <button tabindex="0" id="twitter-share-btn" class="btn-social btn-sm btn-twitter not-sup-dim"
+        <button tabindex="0" id="twitter-share-btn" class="btn-social btn-sm btn-twitter not-sup-dim blocked-dim"
           title="Share an archive with Twitter">
           <img src="images/fa/twitter-brands.svg" alt="Twitter">
         </button>
-        <button tabindex="0" id="linkedin-share-btn" class="btn-social btn-sm btn-linkedin not-sup-dim"
+        <button tabindex="0" id="linkedin-share-btn" class="btn-social btn-sm btn-linkedin not-sup-dim blocked-dim"
           title="Share an archive with LinkedIn">
           <img src="images/fa/linkedin-in-brands.svg" alt="LinkedIn">
         </button>
-        <button tabindex="0" id="copy-link-btn" class="btn-social btn-sm btn-copy not-sup-dim"
+        <button tabindex="0" id="copy-link-btn" class="btn-social btn-sm btn-copy not-sup-dim blocked-dim"
           title="Copy an Archive URL to the Clipboard">
           <img src="images/fa/link-solid.svg" alt="Copy Link">
         </button>

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -103,7 +103,7 @@
       <div class="btn-flex-block">
         <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim blocked-dim" id="site-map-btn"
           title="Display a Site Map for a site, based on archived URLs in the Wayback Machine">Site Map</button>
-        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim" id="tag-cloud-btn"
+        <button type="button" class="btn btn-sm btn-equal btn-light-gray not-sup-dim blocked-dim" id="tag-cloud-btn"
           title="Display a Word Cloud based on a site">Word Cloud</button>
       </div>
 

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.3",
+  "version": "3.1.0.4",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -568,13 +568,6 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       let open_url = message.wayback_url + page_url
       URLopener(open_url, page_url, false)
     }
-  } else if (message.message === 'getLastSaveTime') {
-    // get most recent saved time
-    getCachedWaybackCount(message.page_url,
-      (values) => { sendResponse({ message: 'last_save', timestamp: values.last_ts }) },
-      (error) => { sendResponse({ message: 'last_save', timestamp: '', error: error }) }
-    )
-    return true
   } else if (message.message === 'getWikipediaBooks') {
     // retrieve wikipedia books
     getCachedBooks(message.query,

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -941,9 +941,13 @@ function incrementCount(url) {
   let cacheValues = waybackCountCache[url]
   let timestamp = dateToTimestamp(new Date())
   if (cacheValues && cacheValues.total) {
-    cacheValues.total += 1
-    cacheValues.last_ts = timestamp
-    waybackCountCache[url] = cacheValues
+    if (cacheValues.total > 0) {
+      cacheValues.total += 1
+      cacheValues.last_ts = timestamp
+      waybackCountCache[url] = cacheValues
+    } else {
+      // don't update if total is a special value < 0
+    }
   } else {
     waybackCountCache[url] = { total: 1, last_ts: timestamp }
   }

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -128,7 +128,6 @@ function setupSaveAction(url) {
   if (url && isValidUrl(url) && isNotExcludedUrl(url) && !isArchiveUrl(url)) {
     $('#spn-btn').off('click').on('click', doSaveNow)
     chrome.storage.local.get(['private_mode_setting'], (settings) => {
-      // auto save page
       if (settings && (settings.private_mode_setting === false)) {
         chrome.runtime.sendMessage({
           message: 'getCachedWaybackCount',

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -131,13 +131,16 @@ function setupSaveAction(url) {
       // auto save page
       if (settings && (settings.private_mode_setting === false)) {
         chrome.runtime.sendMessage({
-          message: 'getLastSaveTime',
-          page_url: url
+          message: 'getCachedWaybackCount',
+          url: url
         }, (message) => {
           checkLastError()
-          if (message && (message.message === 'last_save')) {
-            if (message.timestamp) {
-              $('#last-saved-msg').text('Last Saved ' + viewableTimestamp(message.timestamp)).show()
+          if (message) {
+            if (('last_ts' in message) && message.last_ts) {
+              $('#last-saved-msg').text('Last Saved ' + viewableTimestamp(message.last_ts)).show()
+            } else if (('total' in message) && (message.total === -1)) {
+              $('#last-saved-msg').text('URL has been excluded').show()
+              $('.blocked-dim').attr('disabled', true).css('opacity', '0.66').css('cursor', 'not-allowed')
             } else if ('error' in message) {
               $('#last-saved-msg').text('Wayback Machine Unavailable').show()
             } else {
@@ -750,7 +753,7 @@ function showWaybackCount(url) {
   $('#wayback-count-msg').show()
   chrome.runtime.sendMessage({ message: 'getCachedWaybackCount', url: url }, (result) => {
     checkLastError()
-    if (result && ('total' in result)) {
+    if (result && ('total' in result) && (result.total >= 0)) {
       // set label
       let text = ''
       if (result.total === 1) {

--- a/webextension/scripts/popup.js
+++ b/webextension/scripts/popup.js
@@ -138,7 +138,7 @@ function setupSaveAction(url) {
             if (('last_ts' in message) && message.last_ts) {
               $('#last-saved-msg').text('Last Saved ' + viewableTimestamp(message.last_ts)).show()
             } else if (('total' in message) && (message.total === -1)) {
-              $('#last-saved-msg').text('URL has been excluded').show()
+              $('#last-saved-msg').text('URL excluded from viewing').show()
               $('.blocked-dim').attr('disabled', true).css('opacity', '0.66').css('cursor', 'not-allowed')
             } else if ('error' in message) {
               $('#last-saved-msg').text('Wayback Machine Unavailable').show()

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -312,6 +312,10 @@ function getWaybackCount(url, onSuccess, onFail) {
           }
         }
       }
+      // set total to special value if URL is excluded from viewing
+      if (json.error && json.error.type && (json.error.type === 'blocked')) {
+        total = -1
+      }
       let values = { total: total, first_ts: json.first_ts, last_ts: json.last_ts }
       onSuccess(values)
     })


### PR DESCRIPTION
There are over 1K+ websites currently excluded from view on the Wayback Machine.
While Save Page Now on these URLs will still work, one cannot view its archive.

This will:
- Disable the relevant buttons.
- Display a message to inform the user.
- Prevent Auto-Saves from running on excluded pages.
- Fixes #944

Can test against this website:
https://www.tomshardware.com/

Status text `URL has been excluded` changed to `URL excluded from viewing`

![wayback-excluded-light](https://user-images.githubusercontent.com/604259/177756533-4ee73668-4144-496b-b67d-7f318e470e5e.png) ![wayback-excluded-dark](https://user-images.githubusercontent.com/604259/177756564-bff0f7a7-5dca-4bca-85d9-5c41e2a782c6.png)

