### PR TITLE
Move pop-up setting to within 404 setting

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.4;
+				MARKETING_VERSION = 3.1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.4;
+				MARKETING_VERSION = 3.1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.4;
+				MARKETING_VERSION = 3.1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.4;
+				MARKETING_VERSION = 3.1.0.5;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -88,16 +88,16 @@ label[for=tagcloud] {
 }
 
 .embed-popup-group {
-    margin-top: 0.5em;
-    line-height: 1em
+    line-height: 1em;
 }
 
-#embed-popup-setting {
-    margin: 0 0.5em 0 0;
+.embed-popup-group input {
+    margin: 0 7px 0 0 !important;
 }
 
-#embed-popup-label {
-    font-size: 11px;
+.embed-popup-group label {
+    margin: 0;
+    font-size: 11px !important;
 }
 
 

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -87,6 +87,20 @@ label[for=tagcloud] {
     margin-top: 10px;
 }
 
+.embed-popup-group {
+    margin-top: 0.5em;
+    line-height: 1em
+}
+
+#embed-popup-setting {
+    margin: 0 0.5em 0 0;
+}
+
+#embed-popup-label {
+    font-size: 11px;
+}
+
+
 /* tooltips */
 
 .btn-docs {

--- a/webextension/css/settings.css
+++ b/webextension/css/settings.css
@@ -97,7 +97,7 @@ label[for=tagcloud] {
 
 .embed-popup-group label {
     margin: 0;
-    font-size: 11px !important;
+    font-size: 10px !important;
 }
 
 

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -316,9 +316,9 @@
         <div class="setting-text-box">
           <span class="toggle">404 Not Found, etc...</span>
           <img src="images/toolbar/toolbar-icon-Vc16.png" alt="V" class="toolbar-icon">
-          <div style="margin-top: 0.5em; line-height: 1em">
-            <input type="checkbox" class="saved-setting" id="embed-popup-setting" style="margin: 0 0.5em 0 0">
-            <label id="embed-popup-label" for="embed-popup-setting" style="font-size: 11px">pop-up in page</label>
+          <div class="embed-popup-group">
+            <input type="checkbox" class="saved-setting" id="embed-popup-setting">
+            <label for="embed-popup-setting" id="embed-popup-label">pop-up in page</label>
           </div>
         </div>
       </label>

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -277,12 +277,14 @@
           <span class="toggle">Show Resources During Save</span>
         </div>
       </label>
+<!--
       <label class="setting-switch" for="embed-popup-setting">
         <input type="checkbox" class="saved-setting" id="embed-popup-setting">
         <div class="setting-text-box">
           <span class="toggle">Errors Pop-Up in Page</span>
         </div>
       </label>
+-->
       <div class="setting-switch" id="view-setting">
         <div id="view-setting-text">Show Features In</div>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-tab" value="tab">
@@ -312,8 +314,23 @@
       <label class="setting-switch" for="not-found-setting">
         <input type="checkbox" class="saved-setting private-setting" id="not-found-setting">
         <div class="setting-text-box">
-          <span class="toggle">Replace 404s, etc...</span>
+          <!-- <span class="toggle">Replace 404s, etc...</span> -->
+          <span class="toggle">404 Not Found, etc...</span>
           <img src="images/toolbar/toolbar-icon-Vc16.png" alt="V" class="toolbar-icon">
+
+          <div style="margin-top: 0.5em; line-height: 1em">
+            <input type="checkbox" class="saved-setting" id="embed-popup-setting" style="margin: 0 0.5em 0 0">
+            <label id="embed-popup-label" for="embed-popup-setting" style="font-size: 11px">pop-up in page</label>
+          </div>
+
+<!-- REMOVE
+          <div style="margin-top: 0.5em">
+            <select id="embed-popup-setting" class="btn-mini">
+              <option value="true" selected>show pop-up</option>
+              <option value="false">don't show pop-up</option>
+            </select>
+          </div>
+-->
         </div>
       </label>
 

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -277,14 +277,6 @@
           <span class="toggle">Show Resources During Save</span>
         </div>
       </label>
-<!--
-      <label class="setting-switch" for="embed-popup-setting">
-        <input type="checkbox" class="saved-setting" id="embed-popup-setting">
-        <div class="setting-text-box">
-          <span class="toggle">Errors Pop-Up in Page</span>
-        </div>
-      </label>
--->
       <div class="setting-switch" id="view-setting">
         <div id="view-setting-text">Show Features In</div>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-tab" value="tab">

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -314,23 +314,12 @@
       <label class="setting-switch" for="not-found-setting">
         <input type="checkbox" class="saved-setting private-setting" id="not-found-setting">
         <div class="setting-text-box">
-          <!-- <span class="toggle">Replace 404s, etc...</span> -->
           <span class="toggle">404 Not Found, etc...</span>
           <img src="images/toolbar/toolbar-icon-Vc16.png" alt="V" class="toolbar-icon">
-
           <div style="margin-top: 0.5em; line-height: 1em">
             <input type="checkbox" class="saved-setting" id="embed-popup-setting" style="margin: 0 0.5em 0 0">
             <label id="embed-popup-label" for="embed-popup-setting" style="font-size: 11px">pop-up in page</label>
           </div>
-
-<!-- REMOVE
-          <div style="margin-top: 0.5em">
-            <select id="embed-popup-setting" class="btn-mini">
-              <option value="true" selected>show pop-up</option>
-              <option value="false">don't show pop-up</option>
-            </select>
-          </div>
--->
         </div>
       </label>
 

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.4",
+  "version": "3.1.0.5",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -40,7 +40,6 @@ function restoreSettings(items) {
   $('#my-archive-setting').prop('checked', items.my_archive_setting)
   $('#resource-list-setting').prop('checked', items.resource_list_setting)
   $('#embed-popup-setting').prop('checked', items.embed_popup_setting)
-  // $('#embed-popup-setting').val(items.embed_popup_setting || 'true') // TEST REMOVE
   $(`input[name=view-setting-input][value=${items.view_setting}]`).prop('checked', true)
   // update UI
   enableEmbedPopupSetting(items.not_found_setting)
@@ -66,7 +65,6 @@ function saveSettings() {
     my_archive_setting: $('#my-archive-setting').prop('checked'),
     resource_list_setting: $('#resource-list-setting').prop('checked'),
     embed_popup_setting: $('#embed-popup-setting').prop('checked'),
-    // embed_popup_setting: $('#embed-popup-setting').val(), // TEST REMOVE
     view_setting: $('input[name=view-setting-input]:checked').val()
   }
   chrome.storage.local.set(settings)
@@ -134,17 +132,9 @@ function setupSettingsChange() {
   })
 
   // 404 embed-popup-setting
-  // enableEmbedPopupSetting($('#not-found-setting').prop('checked') != false) // doesn't work here - REMOVE
   $('#not-found-setting').change((e) => {
-    console.log('change 404 setting') // DEBUG
     enableEmbedPopupSetting($(e.target).prop('checked') === true)
   })
-
-  /* // DOESN'T WORK - REMOVE
-  $('#embed-popup-setting').mousedown((e) => {
-    e.stopPropagation()
-  })
-  */
 
   // resources
   $('#wiki-setting').change((e) => {
@@ -221,8 +211,7 @@ function setupHelpDocs() {
     'auto-archive-setting': 'Archive URLs that have not previously been archived to the Wayback Machine.',
     'email-outlinks-setting': 'Send an email of results when Outlinks option is selected.',
     'my-archive-setting': 'Adds URL to My Web Archive when Save Page Now is selected.',
-    'resource-list-setting': 'Display embedded URLs archived with Save Page Now.',
-    /* 'embed-popup-setting': 'Also present error conditions such as 404s via pop-up within website.' */ // REMOVE
+    'resource-list-setting': 'Display embedded URLs archived with Save Page Now.'
   }
   let labels = $('label')
   for (let i = 0; i < labels.length; i++) {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -40,7 +40,10 @@ function restoreSettings(items) {
   $('#my-archive-setting').prop('checked', items.my_archive_setting)
   $('#resource-list-setting').prop('checked', items.resource_list_setting)
   $('#embed-popup-setting').prop('checked', items.embed_popup_setting)
+  // $('#embed-popup-setting').val(items.embed_popup_setting || 'true') // TEST REMOVE
   $(`input[name=view-setting-input][value=${items.view_setting}]`).prop('checked', true)
+  // update UI
+  enableEmbedPopupSetting(items.not_found_setting)
 }
 
 function saveSettings() {
@@ -63,6 +66,7 @@ function saveSettings() {
     my_archive_setting: $('#my-archive-setting').prop('checked'),
     resource_list_setting: $('#resource-list-setting').prop('checked'),
     embed_popup_setting: $('#embed-popup-setting').prop('checked'),
+    // embed_popup_setting: $('#embed-popup-setting').val(), // TEST REMOVE
     view_setting: $('input[name=view-setting-input]:checked').val()
   }
   chrome.storage.local.set(settings)
@@ -93,6 +97,17 @@ function onPrivateSettingChange(e) {
   }
 }
 
+// Enable or disable setting when flag is true or false.
+function enableEmbedPopupSetting(flag) {
+  if (flag) {
+    $('#embed-popup-setting').attr('disabled', false)
+    $('#embed-popup-label').css('opacity', '1.0').css('cursor', '')
+  } else {
+    $('#embed-popup-setting').attr('disabled', true)
+    $('#embed-popup-label').css('opacity', '0.66').css('cursor', 'not-allowed')
+  }
+}
+
 // Save settings on change and other actions on particular settings.
 function setupSettingsChange() {
 
@@ -117,6 +132,19 @@ function setupSettingsChange() {
       chrome.runtime.sendMessage({ message: 'clearCountCache' })
     }
   })
+
+  // 404 embed-popup-setting
+  // enableEmbedPopupSetting($('#not-found-setting').prop('checked') != false) // doesn't work here - REMOVE
+  $('#not-found-setting').change((e) => {
+    console.log('change 404 setting') // DEBUG
+    enableEmbedPopupSetting($(e.target).prop('checked') === true)
+  })
+
+  /* // DOESN'T WORK - REMOVE
+  $('#embed-popup-setting').mousedown((e) => {
+    e.stopPropagation()
+  })
+  */
 
   // resources
   $('#wiki-setting').change((e) => {
@@ -194,7 +222,7 @@ function setupHelpDocs() {
     'email-outlinks-setting': 'Send an email of results when Outlinks option is selected.',
     'my-archive-setting': 'Adds URL to My Web Archive when Save Page Now is selected.',
     'resource-list-setting': 'Display embedded URLs archived with Save Page Now.',
-    'embed-popup-setting': 'Also present error conditions such as 404s via pop-up within website.'
+    /* 'embed-popup-setting': 'Also present error conditions such as 404s via pop-up within website.' */ // REMOVE
   }
   let labels = $('label')
   for (let i = 0; i < labels.length; i++) {


### PR DESCRIPTION
This is a Settings UI change to move the "Errors Pop-Up in Page" Setting in the first panel, to inside the 404 Setting in the second panel. When the 404 setting isn't active, the pop-up setting is disabled.

| Before | After |
| --- | --- |
![settings1-before](https://user-images.githubusercontent.com/604259/180591598-e0ac9f0b-dd90-4334-aa7a-3302dce22c5a.png) | ![settings1-after](https://user-images.githubusercontent.com/604259/180591614-f7b8fed5-52af-42da-8b99-7e481f84464d.png)
![settings2-before](https://user-images.githubusercontent.com/604259/180591607-601f410e-0e30-460a-b640-f66b8d1e01bd.png) | ![settings2-after](https://user-images.githubusercontent.com/604259/180591618-686026b3-895c-4cf6-bf09-4a88879a49a8.png)

