### PR TITLE
Option to Disable Notifications

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.5;
+				MARKETING_VERSION = 3.1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.5;
+				MARKETING_VERSION = 3.1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.5;
+				MARKETING_VERSION = 3.1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.5;
+				MARKETING_VERSION = 3.1.0.6;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -277,7 +277,7 @@
           <span class="toggle">Show Resources During Save</span>
         </div>
       </label>
-      <label class="setting-switch" for="notify-setting">
+      <label class="setting-switch" for="notify-setting" id="notify-label">
         <input type="checkbox" class="saved-setting" id="notify-setting">
         <div class="setting-text-box">
           <span class="toggle">Disable Notifications</span>

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -277,12 +277,20 @@
           <span class="toggle">Show Resources During Save</span>
         </div>
       </label>
+      <label class="setting-switch" for="notify-setting">
+        <input type="checkbox" class="saved-setting" id="notify-setting">
+        <div class="setting-text-box">
+          <span class="toggle">Disable Notifications</span>
+        </div>
+      </label>
+<!--
       <label class="setting-switch" for="embed-popup-setting">
         <input type="checkbox" class="saved-setting" id="embed-popup-setting">
         <div class="setting-text-box">
           <span class="toggle">Errors Pop-Up in Page</span>
         </div>
       </label>
+-->
       <div class="setting-switch" id="view-setting">
         <div id="view-setting-text">Show Features In</div>
         <input class="saved-setting" type="radio" name="view-setting-input" id="view-setting-tab" value="tab">

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.5",
+  "version": "3.1.0.6",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -34,19 +34,6 @@ function rewriteUserAgentHeader(e) {
   return { requestHeaders: e.requestHeaders }
 }
 
-function URLopener(open_url, url, wmIsAvailable) {
-  if (wmIsAvailable === true) {
-    wmAvailabilityCheck(url, () => {
-      openByWindowSetting(open_url)
-    }, () => {
-      const msg = 'This page has not been archived.'
-      if (isFirefox) { notify(msg) } else { alert(msg) }
-    })
-  } else {
-    openByWindowSetting(open_url)
-  }
-}
-
 /* * * API Calls * * */
 
 // First checks for login state before calling savePageNow()
@@ -565,8 +552,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     // open URL in new tab or window depending on setting
     let page_url = getCleanUrl(message.page_url)
     if (isValidUrl(page_url) && isNotExcludedUrl(page_url)) {
-      let open_url = message.wayback_url + page_url
-      URLopener(open_url, page_url, false)
+      openByWindowSetting(message.wayback_url + page_url)
     }
   } else if (message.message === 'getLastSaveTime') {
     // get most recent saved time
@@ -1098,8 +1084,7 @@ chrome.contextMenus.onClicked.addListener((click) => {
           savePageNowChecked(atab, page_url, false, options)
           return true
         }
-        let open_url = wayback_url + page_url
-        URLopener(open_url, page_url, false)
+        openByWindowSetting(wayback_url + page_url)
       } else {
         const msg = 'This URL is excluded.'
         if (isFirefox) { notify(msg) } else { alert(msg) }

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -4,10 +4,10 @@
 // Copyright 2016-2020, Internet Archive
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL, isFirefox */
+/*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL */
 /*   global initDefaultOptions, badgeCountText, getWaybackCount, newshosts, dateToTimestamp, fixedEncodeURIComponent, checkLastError */
 /*   global hostHeaders, gCustomUserAgent, timestampToDate, isBadgeOnTop, isUrlInList, getTabKey, saveTabData, readTabData, initAutoExcludeList */
-/*   global isDevVersion, checkAuthentication, setupContextMenus, cropPrefix */
+/*   global isDevVersion, checkAuthentication, setupContextMenus, cropPrefix, alertMessage */
 
 // Used to store the statuscode of the if it is a httpFailCodes
 let gStatusCode = 0
@@ -1086,8 +1086,7 @@ chrome.contextMenus.onClicked.addListener((click) => {
         }
         openByWindowSetting(wayback_url + page_url)
       } else {
-        const msg = 'This URL is excluded.'
-        if (isFirefox) { notify(msg) } else { alert(msg) }
+        alertMessage('URL not supported.')
       }
     }
   })

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -4,10 +4,10 @@
 // Copyright 2016-2020, Internet Archive
 
 // from 'utils.js'
-/*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notify, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL */
+/*   global isNotExcludedUrl, getCleanUrl, isArchiveUrl, isValidUrl, notifyMsg, openByWindowSetting, sleep, wmAvailabilityCheck, hostURL */
 /*   global initDefaultOptions, badgeCountText, getWaybackCount, newshosts, dateToTimestamp, fixedEncodeURIComponent, checkLastError */
 /*   global hostHeaders, gCustomUserAgent, timestampToDate, isBadgeOnTop, isUrlInList, getTabKey, saveTabData, readTabData, initAutoExcludeList */
-/*   global isDevVersion, checkAuthentication, setupContextMenus, cropPrefix, alertMessage */
+/*   global isDevVersion, checkAuthentication, setupContextMenus, cropPrefix, alertMsg */
 
 // Used to store the statuscode of the if it is a httpFailCodes
 let gStatusCode = 0
@@ -94,7 +94,7 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
         if (errMsg.indexOf('same snapshot') !== -1) {
           // snapshot already archived within timeframe
           chrome.runtime.sendMessage({ message: 'save_archived', error: errMsg, url: pageUrl, atab: atab }, checkLastError)
-          if (!silent) { notify(errMsg) }
+          if (!silent) { notifyMsg(errMsg) }
         } else {
           // update UI
           addToolbarState(atab, 'S')
@@ -102,7 +102,7 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
           chrome.runtime.sendMessage({ message: 'save_start', atab: atab, url: pageUrl }, checkLastError)
           // show resources during save
           if (!silent) {
-            notify('Saving ' + pageUrl)
+            notifyMsg('Saving ' + pageUrl)
             chrome.storage.local.get(['resource_list_setting'], (settings) => {
               if (settings && settings.resource_list_setting) {
                 const resource_list_url = chrome.runtime.getURL('resource-list.html') + '?url=' + pageUrl + '&job_id=' + jobId + '#not_refreshed'
@@ -117,7 +117,7 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
       } else {
         // missing jobId error
         chrome.runtime.sendMessage({ message: 'save_error', error: errMsg, url: pageUrl, atab: atab }, checkLastError)
-        if (!silent) { notify('Error: ' + errMsg) }
+        if (!silent) { notifyMsg('Error: ' + errMsg) }
       }
     })
     .catch((err) => {
@@ -217,7 +217,7 @@ function statusSuccess(atab, pageUrl, silent, data) {
     if (('message' in data) && (data.message.length > 0)) {
       msg = data.message
     }
-    notify(msg, (notificationId) => {
+    notifyMsg(msg, (notificationId) => {
       chrome.notifications && chrome.notifications.onClicked.addListener((newNotificationId) => {
         if (notificationId === newNotificationId) {
           openByWindowSetting('https://web.archive.org/web/' + data.timestamp + '/' + data.original_url)
@@ -254,7 +254,7 @@ function statusFailed(atab, pageUrl, silent, data, err) {
     }, checkLastError)
     // notify
     if (!silent) {
-      notify('Error: ' + data.message, (notificationId) => {
+      notifyMsg('Error: ' + data.message, (notificationId) => {
         chrome.notifications && chrome.notifications.onClicked.addListener((newNotificationId) => {
           if (notificationId === newNotificationId) {
             openByWindowSetting('https://archive.org/account/login')
@@ -1086,7 +1086,7 @@ chrome.contextMenus.onClicked.addListener((click) => {
         }
         openByWindowSetting(wayback_url + page_url)
       } else {
-        alertMessage('URL not supported.')
+        alertMsg('URL not supported.')
       }
     }
   })

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -201,6 +201,7 @@ function setupHelpDocs() {
     'auto-archive-setting': 'Archive URLs that have not previously been archived to the Wayback Machine.',
     'email-outlinks-setting': 'Send an email of results when Outlinks option is selected.',
     'my-archive-setting': 'Adds URL to My Web Archive when Save Page Now is selected.',
+    'notify-setting': 'Turn off all notifications.',
     'resource-list-setting': 'Display embedded URLs archived with Save Page Now.',
     'embed-popup-setting': 'Also present error conditions such as 404s via pop-up within website.'
   }

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -39,6 +39,7 @@ function restoreSettings(items) {
   $('#email-outlinks-setting').prop('checked', items.email_outlinks_setting)
   $('#my-archive-setting').prop('checked', items.my_archive_setting)
   $('#resource-list-setting').prop('checked', items.resource_list_setting)
+  $('#notify-setting').prop('checked', items.notify_setting)
   $('#embed-popup-setting').prop('checked', items.embed_popup_setting)
   $(`input[name=view-setting-input][value=${items.view_setting}]`).prop('checked', true)
 }
@@ -62,6 +63,7 @@ function saveSettings() {
     email_outlinks_setting: $('#email-outlinks-setting').prop('checked'),
     my_archive_setting: $('#my-archive-setting').prop('checked'),
     resource_list_setting: $('#resource-list-setting').prop('checked'),
+    notify_setting: $('#notify-setting').prop('checked'),
     embed_popup_setting: $('#embed-popup-setting').prop('checked'),
     view_setting: $('input[name=view-setting-input]:checked').val()
   }
@@ -104,6 +106,12 @@ function setupSettingsChange() {
     $('#auto-archive-setting').prop('checked', true).trigger('change')
     e.target.blur()
   })
+
+  // notify setting
+  // hide setting if notifications unsupported (e.g. Safari)
+  if (!chrome.notifications) {
+    $('#notify-label').hide()
+  }
 
   // view setting
   $('#view-setting').click(switchTabWindow)

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -657,11 +657,11 @@ function opener(url, option, callback) {
 // Displays a notification by the OS.
 // Safari does nothing.
 //
-function notify(message, callback) {
+function notifyMsg(msg, callback) {
   let options = {
     type: 'basic',
     title: 'Wayback Machine',
-    message: message,
+    message: msg,
     iconUrl: chrome.runtime.getURL('images/app-icon/app-icon96.png')
   }
   chrome.notifications && chrome.notifications.create(options, callback)
@@ -672,8 +672,8 @@ function notify(message, callback) {
 //   Firefox: Errors on alert(), so show notification instead.
 //   Safari: Ignores alert()
 //
-function alertMessage(msg) {
-  if (isFirefox) { notify(msg) } else { alert(msg) }
+function alertMsg(msg) {
+  if (isFirefox) { notifyMsg(msg) } else { alert(msg) }
 }
 
 function checkLastError() {
@@ -819,8 +819,8 @@ if (typeof module !== 'undefined') {
     wmAvailabilityCheck,
     openByWindowSetting,
     sleep,
-    notify,
-    alertMessage,
+    notifyMsg,
+    alertMsg,
     attachTooltip,
     getUserInfo,
     checkAuthentication,

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -655,16 +655,23 @@ function opener(url, option, callback) {
 }
 
 // Displays a notification by the OS.
-// Safari does nothing.
+// Unless Disable Notificaions setting is true.
+// Safari doesn't support notifications so this will do nothing.
 //
 function notifyMsg(msg, callback) {
-  let options = {
-    type: 'basic',
-    title: 'Wayback Machine',
-    message: msg,
-    iconUrl: chrome.runtime.getURL('images/app-icon/app-icon96.png')
+  if (chrome.notifications) {
+    chrome.storage.local.get(['notify_setting'], (settings) => {
+      if (settings && !settings.notify_setting) {
+        const options = {
+          type: 'basic',
+          title: 'Wayback Machine',
+          message: msg,
+          iconUrl: chrome.runtime.getURL('images/app-icon/app-icon96.png')
+        }
+        chrome.notifications.create(options, callback)
+      }
+    })
   }
-  chrome.notifications && chrome.notifications.create(options, callback)
 }
 
 // Pop up an alert message.

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -654,6 +654,9 @@ function opener(url, option, callback) {
   }
 }
 
+// Displays a notification by the OS.
+// Safari does nothing.
+//
 function notify(message, callback) {
   let options = {
     type: 'basic',
@@ -662,6 +665,15 @@ function notify(message, callback) {
     iconUrl: chrome.runtime.getURL('images/app-icon/app-icon96.png')
   }
   chrome.notifications && chrome.notifications.create(options, callback)
+}
+
+// Pop up an alert message.
+//   Chrome & Edge: Popup alert modal.
+//   Firefox: Errors on alert(), so show notification instead.
+//   Safari: Ignores alert()
+//
+function alertMessage(msg) {
+  if (isFirefox) { notify(msg) } else { alert(msg) }
 }
 
 function checkLastError() {
@@ -808,6 +820,7 @@ if (typeof module !== 'undefined') {
     openByWindowSetting,
     sleep,
     notify,
+    alertMessage,
     attachTooltip,
     getUserInfo,
     checkAuthentication,


### PR DESCRIPTION
Implements #902 

Adds "Disable Notifications" to Settings which will turn off any notifications from displaying in Chrome, Firefox, and Edge. This Setting will be hidden on Safari, since Safari already never displays notifications. If this changes in the future, the Setting will then display depending on if the browser supports it.

This PR also refactors and cleans up unused code related to alerts and notifications.

<img width="215" alt="settings-disable-notifications" src="https://user-images.githubusercontent.com/604259/181184142-b16aa92b-8507-4f06-93d3-58586c488c94.png">

