### PR TITLE
Remove an url that longer redirects to 404 from testing guide

### DIFF
--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -109,9 +109,6 @@ Any URL
 - https://www.whitehouse.gov/energy/climate-change
 - http://purl.oclc.org/docs/inet96.html
 
-302 Redirect to 404 above:
-- http://purl.oclc.org/OCLC/PURL/INET96
-
 410 Page has gone:
 - https://medium.com/@communismkills/here-are-the-companies-that-support-antifa-black-lives-matter-and-want-you-dead-1d79b1845f59
 


### PR DESCRIPTION
Remove an url that longer redirects to 404 from testing guide