### PR TITLE
Auto Save New Bookmarks

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.8;
+				MARKETING_VERSION = 3.1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.8;
+				MARKETING_VERSION = 3.1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.8;
+				MARKETING_VERSION = 3.1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.8;
+				MARKETING_VERSION = 3.1.0.9;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -259,6 +259,12 @@
           </div>
         </div>
       </label>
+      <label class="setting-switch" for="auto-bookmark-setting" id="auto-bookmark-label">
+        <input type="checkbox" class="saved-setting" id="auto-bookmark-setting">
+        <div class="setting-text-box">
+          <span class="toggle">Auto Save Bookmarks</span>
+        </div>
+      </label>
       <label class="setting-switch auth-click2" for="email-outlinks-setting">
         <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="email-outlinks-setting"></span>
         <div class="setting-text-box">

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -26,7 +26,6 @@
   "homepage_url": "https://archive.org/",
   "permissions": [
       "activeTab",
-      "bookmarks",
       "cookies",
       "contextMenus",
       "notifications",
@@ -37,6 +36,9 @@
       "https://*.archive.org/*",
       "https://hypothes.is/*",
       "<all_urls>"
+  ],
+  "optional_permissions": [
+      "bookmarks"
   ],
   "background": {
     "scripts": ["scripts/utils.js",

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.8",
+  "version": "3.1.0.9",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -26,6 +26,7 @@
   "homepage_url": "https://archive.org/",
   "permissions": [
       "activeTab",
+      "bookmarks",
       "cookies",
       "contextMenus",
       "notifications",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -872,7 +872,7 @@ function autoSaveChecked(atab, url, beforeDate) {
 function autoBookmarksListener(id, bookmark) {
   // This runs whenever a bookmark is saved.
   console.log('autoBookmarksListener ', bookmark) // DEBUG
-  if (('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url) ) {
+  if (('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url)) {
     chrome.storage.local.get(['auto_bookmark_setting'], (settings) => {
       if (settings && settings.auto_bookmark_setting) {
         chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
@@ -897,12 +897,15 @@ function setupAutoSaveBookmarks() {
   chrome.bookmarks && chrome.bookmarks.onCreated && chrome.bookmarks.onCreated.addListener(autoBookmarksListener)
 }
 
-// Called when 'bookmarks' permission is acquired.
+// Called when an optional permission is acquired such as 'bookmarks'.
 chrome.permissions.onAdded.addListener((permissions) => {
   console.log('permissions onAdded') // DEBUG
   if (permissions.permissions.indexOf('bookmarks') >= 0) {
     setupAutoSaveBookmarks()
-    // bug fix to set setting here because when popup goes away, code in settings.js won't run
+    // Bug fix to set setting value because when popup goes away, code in settings.js won't run.
+    // FIXME: This is a Hack which may be unintended if any other code attempts to request the
+    // 'bookmarks' permission (or ANY optional permission!) in the future. (e.g. Bulk Save)
+    // It's hard to see a solution without major refactoring since dependent functions are all in background.js
     chrome.storage.local.set({ auto_bookmark_setting: true })
   }
 })

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -871,7 +871,6 @@ function autoSaveChecked(atab, url, beforeDate) {
 // Add a listener for handling Auto Save Bookmarks.
 function autoBookmarksListener(id, bookmark) {
   // This runs whenever a bookmark is saved.
-  console.log('autoBookmarksListener ', bookmark) // DEBUG
   if (('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url)) {
     chrome.storage.local.get(['auto_bookmark_setting'], (settings) => {
       if (settings && settings.auto_bookmark_setting) {
@@ -891,7 +890,6 @@ function autoBookmarksListener(id, bookmark) {
 
 // Should call this after 'bookmarks' permission Allowed and on start.
 function setupAutoSaveBookmarks() {
-  console.log('setupAutoSaveBookmarks') // DEBUG
   // adding a named function instead of anonymous function should prevent multiple listeners from being added.
   // safari doesn't support chrome.bookmarks
   chrome.bookmarks && chrome.bookmarks.onCreated && chrome.bookmarks.onCreated.addListener(autoBookmarksListener)
@@ -899,7 +897,6 @@ function setupAutoSaveBookmarks() {
 
 // Called when an optional permission is acquired such as 'bookmarks'.
 chrome.permissions.onAdded.addListener((permissions) => {
-  console.log('permissions onAdded') // DEBUG
   if (permissions.permissions.indexOf('bookmarks') >= 0) {
     setupAutoSaveBookmarks()
     // Bug fix to set setting value because when popup goes away, code in settings.js won't run.

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -83,6 +83,7 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
   })
 
   // call api
+  console.log('archiving: ' + pageUrl)
   timeoutPromise
     .then(response => (loggedInFlag ? response.json() : response.text()))
     .then(async (data) => {
@@ -890,13 +891,12 @@ if (chrome.bookmarks) {
     if (gBookmarksOn && ('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url) ) {
       chrome.storage.local.get(['auto_bookmark_setting'], (settings) => {
         if (settings && settings.auto_bookmark_setting) {
-          // BUG: When bookmarking "All Tabs" this may save too many at once, causing issues.
           chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-            if (tabs && tabs[0]) {
-              console.log('archiving bookmark: ' + bookmark.url)
+            // The check here that current tab URL == bookmark URL is a temp solution to
+            // the issue caused when bookmarking "All Tabs" which could cause too many saves at once.
+            // This forces only 1 URL to be saved. Also prevents importing URLs on Firefox from saving.
+            if (tabs && tabs[0] && (tabs[0].url === bookmark.url)) {
               autoSave(tabs[0], bookmark.url)
-            } else {
-              console.log('failed to retrieve current tab!')
             }
           })
         }

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -873,23 +873,9 @@ function autoSaveChecked(atab, url, beforeDate) {
 //
 // FIXME: this will be false until permission allowed, so will fail to run!
 if (chrome.bookmarks) {
-  let gBookmarksOn = true
-
-  // Disables onCreated callback from running while import taking place. Firefox not supported.
-  chrome.bookmarks.onImportBegan && chrome.bookmarks.onImportBegan.addListener(() => {
-    console.log('bookmarks.onImportBegan')
-    gBookmarksOn = false
-  })
-
-  // Re-enables onCreated callback after importing ends. Firefox not supported.
-  chrome.bookmarks.onImportEnded && chrome.bookmarks.onImportEnded.addListener(() => {
-    console.log('bookmarks.onImportEnded')
-    gBookmarksOn = true
-  })
-
   // Runs whenever a bookmark is saved.
   chrome.bookmarks.onCreated && chrome.bookmarks.onCreated.addListener((id, bookmark) => {
-    if (gBookmarksOn && ('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url) ) {
+    if (('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url) ) {
       chrome.storage.local.get(['auto_bookmark_setting'], (settings) => {
         if (settings && settings.auto_bookmark_setting) {
           chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -871,6 +871,7 @@ function autoSaveChecked(atab, url, beforeDate) {
 // Functions for handling Auto Save Bookmarks.
 // Safari not supported.
 //
+// FIXME: this will be false until permission allowed, so will fail to run!
 if (chrome.bookmarks) {
   let gBookmarksOn = true
 

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -890,7 +890,7 @@ if (chrome.bookmarks) {
     if (gBookmarksOn && ('url' in bookmark) && isValidUrl(bookmark.url) && isNotExcludedUrl(bookmark.url) && !isArchiveUrl(bookmark.url) ) {
       chrome.storage.local.get(['auto_bookmark_setting'], (settings) => {
         if (settings && settings.auto_bookmark_setting) {
-          // BUG: When bookmarking "All Tabs" this will likely only save 1 URL! We don't currently have a fix.
+          // BUG: When bookmarking "All Tabs" this may save too many at once, causing issues.
           chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
             if (tabs && tabs[0]) {
               console.log('archiving bookmark: ' + bookmark.url)

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -678,7 +678,7 @@ chrome.tabs.onUpdated.addListener((tabId, info, tab) => {
     chrome.storage.local.get(['not_found_setting', 'auto_archive_setting', 'auto_archive_age', 'fact_check_setting', 'wiki_setting'], (settings) => {
       // auto save page
       if (settings && settings.auto_archive_setting) {
-        let beforeData = null
+        let beforeDate = null
         if (settings.auto_archive_age) {
           // auto_archive_age is an int of days before now
           const days = parseInt(settings.auto_archive_age, 10)

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -879,6 +879,7 @@ function autoBookmarksListener(id, bookmark) {
           // The check here that current tab URL == bookmark URL is a temp solution to
           // the issue caused when bookmarking "All Tabs" which could cause too many saves at once.
           // This forces only 1 URL to be saved. Also prevents importing URLs from saving any.
+          // Trying to solve multiple URLs would require a queue. Could open a Bulk Save window?
           if (tabs && tabs[0] && (tabs[0].url === bookmark.url)) {
             autoSave(tabs[0], bookmark.url)
           }
@@ -901,6 +902,8 @@ chrome.permissions.onAdded.addListener((permissions) => {
   console.log('permissions onAdded') // DEBUG
   if (permissions.permissions.indexOf('bookmarks') >= 0) {
     setupAutoSaveBookmarks()
+    // bug fix to set setting here because when popup goes away, code in settings.js won't run
+    chrome.storage.local.set({ auto_bookmark_setting: true })
   }
 })
 

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -83,7 +83,6 @@ function savePageNow(atab, pageUrl, silent = false, options = {}, loggedInFlag =
   })
 
   // call api
-  console.log('archiving: ' + pageUrl)
   timeoutPromise
     .then(response => (loggedInFlag ? response.json() : response.text()))
     .then(async (data) => {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -110,19 +110,6 @@ function enableEmbedPopupSetting(flag) {
   }
 }
 
-// Popup request for optional bookmarks permission if not yet set to allowed.
-function checkBookmarksPermission() {
-  // first clear checkbox before permissions popup
-  // $('#auto-bookmark-setting').prop('checked', false) // REMOVE
-  // permissions popup causes extension popup to disappear
-  chrome.permissions.request({ permissions: ['bookmarks'] }, (granted) => {
-    if (granted) {
-      $('#auto-bookmark-setting').prop('checked', true)
-      saveSettings()
-    }
-  })
-}
-
 // Save settings on change and other actions on particular settings.
 function setupSettingsChange() {
 
@@ -135,16 +122,26 @@ function setupSettingsChange() {
     e.target.blur()
   })
 
-  // auto bookmark
-  // hide setting if bookmarks unsupported (e.g. Safari)
+  // auto save bookmarks
   if (!chrome.bookmarks) { // TODO: need to rethink, as bookmarks is null prior to permission set to Allow
+    // hide setting if bookmarks unsupported (e.g. Safari)
     // $('#auto-bookmark-label').hide()
   }
+
+  // Before setting Auto Save Bookmarks, check optional 'bookmarks' permission and popup request if not yet acquired.
   $('#auto-bookmark-setting').click((e) => {
     if ($(e.target).prop('checked') === true) {
-      // while attempting to turn on setting, first check permissions
       e.preventDefault()
-      checkBookmarksPermission()
+      chrome.permissions.request({ permissions: ['bookmarks'] }, (granted) => {
+        if (granted) {
+          console.log('granted') // DEBUG
+          // Set checkmark and save it since it was prevented.
+          // Permissions popup will cause popup to disappear, causing this code to not run.
+          // Fixed by saving auto_bookmark_setting to true in background.js when permission granted.
+          $('#auto-bookmark-setting').prop('checked', true)
+          saveSettings()
+        }
+      })
     }
   })
 

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -36,6 +36,7 @@ function restoreSettings(items) {
   // second panel
   $('#auto-archive-setting').prop('checked', items.auto_archive_setting)
   $('#auto-archive-age').val(items.auto_archive_age || '99999')
+  $('#auto-bookmark-setting').prop('checked', items.auto_bookmark_setting)
   $('#email-outlinks-setting').prop('checked', items.email_outlinks_setting)
   $('#my-archive-setting').prop('checked', items.my_archive_setting)
   $('#resource-list-setting').prop('checked', items.resource_list_setting)
@@ -62,6 +63,7 @@ function saveSettings() {
     // second panel
     auto_archive_setting: $('#auto-archive-setting').prop('checked'),
     auto_archive_age: $('#auto-archive-age').val(),
+    auto_bookmark_setting: $('#auto-bookmark-setting').prop('checked'),
     email_outlinks_setting: $('#email-outlinks-setting').prop('checked'),
     my_archive_setting: $('#my-archive-setting').prop('checked'),
     resource_list_setting: $('#resource-list-setting').prop('checked'),
@@ -217,6 +219,7 @@ function setupHelpDocs() {
     'tvnews-setting': 'Auto check for related TV News Clips while visiting selected news websites.',
     // general tab
     'auto-archive-setting': 'Archive URLs that have not previously been archived to the Wayback Machine.',
+    'auto-bookmark-setting': 'Archive when a website is bookmarked, except if on the Exclude URLs list.',
     'email-outlinks-setting': 'Send an email of results when Outlinks option is selected.',
     'my-archive-setting': 'Adds URL to My Web Archive when Save Page Now is selected.',
     'notify-setting': 'Turn off all notifications.',

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -122,6 +122,12 @@ function setupSettingsChange() {
     e.target.blur()
   })
 
+  // auto bookmark
+  // hide setting if bookmarks unsupported (e.g. Safari)
+  if (!chrome.bookmarks) {
+    $('#auto-bookmark-label').hide()
+  }
+
   // notify setting
   // hide setting if notifications unsupported (e.g. Safari)
   if (!chrome.notifications) {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -110,18 +110,15 @@ function enableEmbedPopupSetting(flag) {
   }
 }
 
+// Popup request for optional bookmarks permission if not yet set to allowed.
 function checkBookmarksPermission() {
   // first clear checkbox before permissions popup
-  $('#auto-bookmark-setting').prop('checked', false)
+  // $('#auto-bookmark-setting').prop('checked', false) // REMOVE
   // permissions popup causes extension popup to disappear
   chrome.permissions.request({ permissions: ['bookmarks'] }, (granted) => {
     if (granted) {
-      console.log('granted')
       $('#auto-bookmark-setting').prop('checked', true)
-    } else {
-      // prevent checkbox from being checked
-      console.log('not granted')
-      // $('#auto-bookmark-setting').prop('checked', false)
+      saveSettings()
     }
   })
 }
@@ -140,10 +137,10 @@ function setupSettingsChange() {
 
   // auto bookmark
   // hide setting if bookmarks unsupported (e.g. Safari)
-  if (!chrome.bookmarks) {
+  if (!chrome.bookmarks) { // TODO: need to rethink, as bookmarks is null prior to permission set to Allow
     // $('#auto-bookmark-label').hide()
   }
-  $('#auto-bookmark-setting').change((e) => {
+  $('#auto-bookmark-setting').click((e) => {
     if ($(e.target).prop('checked') === true) {
       // while attempting to turn on setting, first check permissions
       e.preventDefault()

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -124,6 +124,7 @@ function setupSettingsChange() {
 
   // auto save bookmarks
   if (isSafari) {
+    // Tried alternatives to test bookmarks support, but none worked out.
     // hide setting if bookmarks unsupported
     $('#auto-bookmark-label').hide()
   } else {

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -133,7 +133,6 @@ function setupSettingsChange() {
         e.preventDefault()
         chrome.permissions.request({ permissions: ['bookmarks'] }, (granted) => {
           if (granted) {
-            console.log('granted') // DEBUG
             // Set checkmark and save it since it was prevented.
             // Permissions popup will cause main popup to disappear, preventing this code from running.
             // Fixed by saving auto_bookmark_setting to true in background.js when permission granted.

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -110,6 +110,22 @@ function enableEmbedPopupSetting(flag) {
   }
 }
 
+function checkBookmarksPermission() {
+  // first clear checkbox before permissions popup
+  $('#auto-bookmark-setting').prop('checked', false)
+  // permissions popup causes extension popup to disappear
+  chrome.permissions.request({ permissions: ['bookmarks'] }, (granted) => {
+    if (granted) {
+      console.log('granted')
+      $('#auto-bookmark-setting').prop('checked', true)
+    } else {
+      // prevent checkbox from being checked
+      console.log('not granted')
+      // $('#auto-bookmark-setting').prop('checked', false)
+    }
+  })
+}
+
 // Save settings on change and other actions on particular settings.
 function setupSettingsChange() {
 
@@ -125,8 +141,15 @@ function setupSettingsChange() {
   // auto bookmark
   // hide setting if bookmarks unsupported (e.g. Safari)
   if (!chrome.bookmarks) {
-    $('#auto-bookmark-label').hide()
+    // $('#auto-bookmark-label').hide()
   }
+  $('#auto-bookmark-setting').change((e) => {
+    if ($(e.target).prop('checked') === true) {
+      // while attempting to turn on setting, first check permissions
+      e.preventDefault()
+      checkBookmarksPermission()
+    }
+  })
 
   // notify setting
   // hide setting if notifications unsupported (e.g. Safari)


### PR DESCRIPTION
Implements #749 

- Auto Saves when user bookmarks a web page, without notification.
- Ignores excluded URLs including user-defined Exclude URLs.
- Uses optional 'bookmarks' permission to avoid warnings at install time, which means the browser will ask permission when user tries to check the setting for the first time.
- Can't save multiple tabs at once. Will only save the current tab.
- Doesn't attempt to save when importing a list of bookmarks.
- Hides the setting in Safari, since bookmark access not supported.
- Tested on Chrome, Firefox, Edge, and Safari.

<img width="217" alt="auto-save-bookmarks" src="https://user-images.githubusercontent.com/604259/183845697-e8b4d9a4-8ea4-4ac7-bb67-4227930befc4.png">
 