### PR TITLE
Stay logged in after user clears cookies

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.6;
+				MARKETING_VERSION = 3.1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.6;
+				MARKETING_VERSION = 3.1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.6;
+				MARKETING_VERSION = 3.1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.6;
+				MARKETING_VERSION = 3.1.0.7;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.6",
+  "version": "3.1.0.7",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/login.js
+++ b/webextension/scripts/login.js
@@ -74,10 +74,6 @@ function doLogin(e) {
         }, 500)
         $('#email-input').val('')
         $('#password-input').val('')
-        // store auth cookies in storage
-        chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
-          chrome.storage.local.set({ auth_cookies: cookies })
-        })
       }
     })
     .catch((e) => {

--- a/webextension/scripts/login.js
+++ b/webextension/scripts/login.js
@@ -58,7 +58,6 @@ function doLogin(e) {
   loginPromise
     .then(response => response.json())
     .then((res) => {
-      console.log('login response: ', res) // DEBUG TO REMOVE
       $('#login-btn').val('Login')
       if (res.success === false) {
         // login failed
@@ -77,7 +76,6 @@ function doLogin(e) {
         $('#password-input').val('')
         // store auth cookies in storage
         chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
-          console.log('login cookies: ', cookies) // DEBUG TO REMOVE
           chrome.storage.local.set({ auth_cookies: cookies })
         })
       }

--- a/webextension/scripts/login.js
+++ b/webextension/scripts/login.js
@@ -58,6 +58,7 @@ function doLogin(e) {
   loginPromise
     .then(response => response.json())
     .then((res) => {
+      console.log('login response: ', res) // DEBUG TO REMOVE
       $('#login-btn').val('Login')
       if (res.success === false) {
         // login failed
@@ -74,6 +75,11 @@ function doLogin(e) {
         }, 500)
         $('#email-input').val('')
         $('#password-input').val('')
+        // store auth cookies in storage
+        chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
+          console.log('login cookies: ', cookies) // DEBUG TO REMOVE
+          chrome.storage.local.set({ auth_cookies: cookies })
+        })
       }
     })
     .catch((e) => {
@@ -90,6 +96,8 @@ function doLogout() {
   // removes cookies in Chrome & Firefox
   chrome.cookies.remove({ url: 'https://archive.org', name: 'logged-in-user' })
   chrome.cookies.remove({ url: 'https://archive.org', name: 'logged-in-sig' })
+  // remove auth cookies from storage
+  chrome.storage.local.remove(['auth_cookies'])
   // update UI
   loginError()
   clearSettingsOnLogout()

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -176,18 +176,20 @@ function getUserInfo() {
  */
 function checkAuthentication(acallback) {
   chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
-    let loggedIn = false
+    let loggedIn = false, ia_auth = false
     cookies.forEach(cookie => {
       if ((cookie.name === 'logged-in-sig') && cookie.value && (cookie.value.length > 0)) { loggedIn = true }
+      else if ((cookie.name === 'ia-auth') && cookie.value && (cookie.value.length > 0)) { ia_auth = true }
     })
     if (loggedIn) {
       // store auth cookies in storage
       chrome.storage.local.set({ auth_cookies: cookies })
       acallback({ 'auth_check': true })
     } else {
-      // if cookies not set but found in storage, then restore cookies from storage
+      // if cookies not set but found in storage, then restore cookies from storage,
+      // but if user previously logged out of archive.org on the web (ia_auth == true), then don't restore cookies from storage.
       chrome.storage.local.get(['auth_cookies'], (items) => {
-        if (items.auth_cookies) {
+        if (items.auth_cookies && !ia_auth) {
           items.auth_cookies.forEach(authCookie => {
             // set only a subset of keys to avoid TypeErrors
             const newCookie = Object.fromEntries(

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -175,27 +175,32 @@ function getUserInfo() {
  * @param callback(result) : returns object { auth_check: bool } where auth_check == true if logged in, false if not.
  */
 function checkAuthentication(acallback) {
-  chrome.cookies.get({ url: 'https://archive.org', name: 'logged-in-sig' }, (result) => {
-    let loggedIn = (result && result.value && (result.value.length > 0)) || false
-    if (!loggedIn) {
+  chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
+    let loggedIn = false
+    cookies.forEach(cookie => {
+      if ((cookie.name === 'logged-in-sig') && cookie.value && (cookie.value.length > 0)) { loggedIn = true }
+    })
+    if (loggedIn) {
+      // store auth cookies in storage
+      chrome.storage.local.set({ auth_cookies: cookies })
+      acallback({ 'auth_check': true })
+    } else {
       // if cookies not set but found in storage, then restore cookies from storage
       chrome.storage.local.get(['auth_cookies'], (items) => {
         if (items.auth_cookies) {
-          items.auth_cookies.forEach(cookie => {
+          items.auth_cookies.forEach(authCookie => {
             // set only a subset of keys to avoid TypeErrors
-            const cookie2 = Object.fromEntries(
+            const newCookie = Object.fromEntries(
               ['domain', 'expirationDate', 'httpOnly', 'name', 'path', 'sameSite', 'secure', 'storeId', 'url', 'value']
-              .filter(k => k in cookie).map(k => [k, cookie[k]])
+              .filter(k => k in authCookie).map(k => [k, authCookie[k]])
             )
-            cookie2.url = 'https://archive.org'
-            chrome.cookies.set(cookie2)
-            if ((cookie.name === 'logged-in-sig') && cookie.value && (cookie.value.length > 0)) { loggedIn = true }
+            newCookie.url = 'https://archive.org'
+            chrome.cookies.set(newCookie)
+            if ((authCookie.name === 'logged-in-sig') && authCookie.value && (authCookie.value.length > 0)) { loggedIn = true }
           })
         }
         acallback({ 'auth_check': loggedIn })
       })
-    } else {
-      acallback({ 'auth_check': loggedIn })
     }
   })
 }

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -175,24 +175,19 @@ function getUserInfo() {
  * @param callback(result) : returns object { auth_check: bool } where auth_check == true if logged in, false if not.
  */
 function checkAuthentication(acallback) {
-
   chrome.cookies.get({ url: 'https://archive.org', name: 'logged-in-sig' }, (result) => {
     let loggedIn = (result && result.value && (result.value.length > 0)) || false
-    // console.log('checkAuth() loggedIn: ', loggedIn) // DEBUG TO REMOVE
     if (!loggedIn) {
       // if cookies not set but found in storage, then restore cookies from storage
       chrome.storage.local.get(['auth_cookies'], (items) => {
-        // console.log('auth_cookies: ', items) // DEBUG TO REMOVE
         if (items.auth_cookies) {
           items.auth_cookies.forEach(cookie => {
-            // console.log({ cookie }) // DEBUG TO REMOVE
             // set only a subset of keys to avoid TypeErrors
             const cookie2 = Object.fromEntries(
               ['domain', 'expirationDate', 'httpOnly', 'name', 'path', 'sameSite', 'secure', 'storeId', 'url', 'value']
               .filter(k => k in cookie).map(k => [k, cookie[k]])
             )
             cookie2.url = 'https://archive.org'
-            // console.log({ cookie2 }) // DEBUG TO REMOVE
             chrome.cookies.set(cookie2)
             if ((cookie.name === 'logged-in-sig') && cookie.value && (cookie.value.length > 0)) { loggedIn = true }
           })


### PR DESCRIPTION
implements #911

This fixes a common complaint when the user cleared their cookies and found themselves logged out. This PR will keep them logged in until they explicitly log out using the log out button in the extension. This works by storing a copy of the auth cookies in storage and restoring them after cookies were cleared and the user clicks the toolbar button.