### PR TITLE
Prevent Auto Save from re-saving recently saved pages

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.7;
+				MARKETING_VERSION = 3.1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.7;
+				MARKETING_VERSION = 3.1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.7;
+				MARKETING_VERSION = 3.1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.7;
+				MARKETING_VERSION = 3.1.0.8;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.7",
+  "version": "3.1.0.8",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -812,13 +812,12 @@ chrome.tabs.onActivated.addListener((info) => {
  * Runs savePageNow if given tab not currently in saving state.
  * First checks if url available in WM, and only saves if beforeDate is prior
  * to last save date, or saves if never been saved before.
- * Pass in Date.now() for beforeDate to save even if saved before.
  * Will not save URLs blocked by the WM API.
  * @param atab {Tab}: Current tab, required to check save status.
  * @param url {string}: URL to save.
- * @param beforeDate {Date}: Date that will be checked only if url previously saved in WM.
+ * @param beforeDate {Date}: Date that will be checked only if url previously saved in WM. Default = now.
  */
-function autoSave(atab, url, beforeDate) {
+function autoSave(atab, url, beforeDate = new Date()) {
   if (isValidUrl(url) && isNotExcludedUrl(url) && !getToolbarState(atab).has('S')) {
     chrome.storage.local.get(['auto_exclude_list'], (items) => {
       if (!('auto_exclude_list' in items) ||

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -83,10 +83,11 @@ function setupPrivateMode() {
   $('.private-setting').change(onPrivateSettingChange)
 }
 
-// Clear all private checkboxes when private mode turned on.
+// When Private Mode turned on, clear all private checkboxes and clear cached data.
 function onPrivateModeChange(e) {
   if ($('#private-mode-setting').prop('checked') === true) {
     $('.private-setting').prop('checked', false).trigger('change')
+    chrome.runtime.sendMessage({ message: 'clearCountCache' })
   }
 }
 
@@ -134,9 +135,6 @@ function setupSettingsChange() {
   $('#wm-count-setting').change((e) => {
     // displays or clears the count badge, label, oldest and newest tooltips
     setupWaybackCount()
-    if ($(e.target).prop('checked') === false) {
-      chrome.runtime.sendMessage({ message: 'clearCountCache' })
-    }
   })
 
   // 404 embed-popup-setting


### PR DESCRIPTION
Fixes #964

- Replaces Availability API call with cached WM count (sparkline) API call in autoSave().
- Tested on Chrome. Needs testing still on Firefox, Edge, Safari.