### PR TITLE
Welcome right-click context menu item

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -461,7 +461,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.9;
+				MARKETING_VERSION = 3.1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -484,7 +484,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.9;
+				MARKETING_VERSION = 3.1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -510,7 +510,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.9;
+				MARKETING_VERSION = 3.1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -535,7 +535,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.1.0.9;
+				MARKETING_VERSION = 3.1.0.10;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.1.0.9",
+  "version": "3.1.0.10",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -395,7 +395,9 @@ function getCachedFactCheck(url, onSuccess, onFail) {
 chrome.storage.local.get({ agreement: false }, (settings) => {
   if (settings && settings.agreement) {
     chrome.browserAction.setPopup({ popup: chrome.runtime.getURL('index.html') }, checkLastError)
-    setupContextMenus()
+    setupContextMenus(true)
+  } else {
+    setupContextMenus(false)
   }
 })
 
@@ -1109,8 +1111,9 @@ function updateToolbar(atab) {
 
 // Right-click context menu "Wayback Machine" inside the page.
 chrome.contextMenus.onClicked.addListener((click) => {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
+
+  if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       let url = click.linkUrl || tabs[0].url
       if (isValidUrl(url) && isNotExcludedUrl(url)) {
         let page_url = getCleanUrl(url)
@@ -1131,8 +1134,10 @@ chrome.contextMenus.onClicked.addListener((click) => {
       } else {
         alertMsg('URL not supported.')
       }
-    }
-  })
+    })
+  } else if (click.menuItemId === 'welcome') {
+    openByWindowSetting(chrome.runtime.getURL('welcome.html'), 'tab')
+  }
 })
 
 if (typeof module !== 'undefined') {

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -1111,7 +1111,6 @@ function updateToolbar(atab) {
 
 // Right-click context menu "Wayback Machine" inside the page.
 chrome.contextMenus.onClicked.addListener((click) => {
-
   if (['first', 'recent', 'save', 'all'].indexOf(click.menuItemId) >= 0) {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
       let url = click.linkUrl || tabs[0].url

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -768,36 +768,47 @@ function initAutoExcludeList() {
   })
 }
 
-function setupContextMenus() {
-  chrome.contextMenus.create({
-    'id': 'save',
-    'title': 'Save Page Now',
-    'contexts': ['page', 'frame', 'link'],
-    'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
-  }, checkLastError)
-  chrome.contextMenus.create({
-    'type': 'separator',
-    'contexts': ['page', 'frame', 'link'],
-    'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+function setupContextMenus(enabled) {
+  chrome.contextMenus.removeAll(() => {
+    if (enabled) {
+      chrome.contextMenus.create({
+        'id': 'save',
+        'title': 'Save Page Now',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      }, checkLastError)
+      chrome.contextMenus.create({
+        'type': 'separator',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      })
+      chrome.contextMenus.create({
+        'id': 'first',
+        'title': 'Oldest Version',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      }, checkLastError)
+      chrome.contextMenus.create({
+        'id': 'recent',
+        'title': 'Newest Version',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      }, checkLastError)
+      chrome.contextMenus.create({
+        'id': 'all',
+        'title': 'All Versions',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      }, checkLastError)
+    } else {
+      chrome.contextMenus.create({
+        'id': 'welcome',
+        'title': 'Welcome to the Wayback Machine',
+        'contexts': ['page', 'frame', 'link'],
+        'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
+      }, checkLastError)
+    }
   })
-  chrome.contextMenus.create({
-    'id': 'first',
-    'title': 'Oldest Version',
-    'contexts': ['page', 'frame', 'link'],
-    'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
-  }, checkLastError)
-  chrome.contextMenus.create({
-    'id': 'recent',
-    'title': 'Newest Version',
-    'contexts': ['page', 'frame', 'link'],
-    'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
-  }, checkLastError)
-  chrome.contextMenus.create({
-    'id': 'all',
-    'title': 'All Versions',
-    'contexts': ['page', 'frame', 'link'],
-    'documentUrlPatterns': ['*://*/*', 'ftp://*/*']
-  }, checkLastError)
 }
 
 // Default Settings prior to accepting terms.
@@ -835,7 +846,7 @@ function afterAcceptTerms () {
     not_found_setting: true
   })
   chrome.browserAction.setPopup({ popup: chrome.runtime.getURL('index.html') }, checkLastError)
-  setupContextMenus()
+  setupContextMenus(true)
 }
 
 if (typeof module !== 'undefined') {


### PR DESCRIPTION
The right-click menu doesn't currently show when the Welcome Agreement page has not yet been accepted. This PR adds a "Welcome to the Wayback Machine" item to the right-click context menu, that when selected will open the Welcome Privacy Policy page, just like when clicking on the toolbar icon for the first time. This was added for those users who were used to using the right-click menu and may not realize one must first click on the toolbar icon and accept the agreement prior to using the right-click menu.