### PR TITLE
Remove mastodon.archive.org from excluded urls

### DIFF
--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -24,9 +24,9 @@ describe('twitter', () => {
 
 describe('isArchiveUrl', () => {
   var test_cases = [
-    { 'url': 'http://archive.org', 'result': true },
-    { 'url': 'https://archive.org', 'result': true },
-    { 'url': 'http://archive.org/some/path/?key=value', 'result': true },
+    { 'url': 'http://archive.org', 'result': false },
+    { 'url': 'https://archive.org', 'result': false },
+    { 'url': 'http://archive.org/some/path/?key=value', 'result': false },
     { 'url': 'https://web.archive.org', 'result': true },
     { 'url': 'https://web.archive.org/some/path', 'result': true },
     { 'url': 'http://example.com', 'result': false },

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -15,8 +15,6 @@ const defaultAutoExcludeList = [
 
 // list of excluded URLs
 const excluded_urls = [
-  'localhost',
-  '0.0.0.0',
   '127.0.0.1',
   'chrome:',
   'chrome-extension:',
@@ -391,7 +389,7 @@ function isArchiveUrl(url) {
   if (typeof url !== 'string') { return false }
   try {
     const hostname = new URL(url).hostname
-    return (!hostname.startsWith('mastodon')) && (hostname === 'archive.org' || hostname.endsWith('.archive.org'))
+    return (hostname === 'web.archive.org')
   } catch (e) {
     // url not formated correctly
     return false

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -391,7 +391,7 @@ function isArchiveUrl(url) {
   if (typeof url !== 'string') { return false }
   try {
     const hostname = new URL(url).hostname
-    return (hostname === 'archive.org') || hostname.endsWith('.archive.org')
+    return (!hostname.startsWith('mastodon')) && (hostname === 'archive.org' || hostname.endsWith('.archive.org'))
   } catch (e) {
     // url not formated correctly
     return false

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -16,6 +16,8 @@ const defaultAutoExcludeList = [
 // list of excluded URLs
 const excluded_urls = [
   '127.0.0.1',
+  'localhost',
+  '0.0.0.0',
   'chrome:',
   'chrome-extension:',
   'about:',


### PR DESCRIPTION
Make changes in `isArchiveUrl` function to include mastodon.archive.org as a supported url in the extension.