### PR TITLE
Automate JS lint and add CSS lint

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,4 @@
+bootstrap.css
+*.js
+*.json
+*.png

--- a/.stylelintrc.yml
+++ b/.stylelintrc.yml
@@ -1,0 +1,2 @@
+extends:
+   - "stylelint-config-standard"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "build": "webpack",
-    "test": "mocha"
+    "test": "mocha",
+    "lint": "npm run lint:js && npm run lint:css",
+    "lint:js": "eslint webextension/scripts test",
+    "lint:css": "stylelint webextension/css"
   },
   "repository": {
     "type": "git",
@@ -37,6 +40,8 @@
     "mini-css-extract-plugin": "^1.4.1",
     "mocha": ">=8.3.2",
     "style-loader": "^2.0.0",
+    "stylelint": "^14",
+    "stylelint-config-standard": "^29",
     "webpack": "^5.31.2",
     "webpack-cli": "^4.6.0"
   },


### PR DESCRIPTION
Add scripts to `package.json` to be able to run `npm run lint:js` to check ALL JS with a single cmd. Until now, you had to run `eslint` for individual files.

Check not only extension JS code but also unit test JS code.

Add `stylelint` and standard configuration.

Add `npm run lint:css` and `npm run lint` to check all JS / CSS in an easy way.