### PR TITLE
Cookie settings check

### DIFF
--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -226,8 +226,9 @@
 		C3CBA8A726E4511100CC9485 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 1250;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					C3CBA8AE26E4511100CC9485 = {
 						CreatedOnToolsVersion = 12.5.1;
@@ -369,6 +370,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -431,6 +433,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -464,8 +467,8 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.3;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MARKETING_VERSION = 3.3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -489,8 +492,8 @@
 					"@executable_path/../Frameworks",
 					"@executable_path/../../../../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.3;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MARKETING_VERSION = 3.3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -517,8 +520,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.3;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MARKETING_VERSION = 3.3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -544,8 +547,8 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.3;
+				MACOSX_DEPLOYMENT_TARGET = "$(RECOMMENDED_MACOSX_DEPLOYMENT_TARGET)";
+				MARKETING_VERSION = 3.3.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/safari/Wayback Machine.xcodeproj/project.pbxproj
+++ b/safari/Wayback Machine.xcodeproj/project.pbxproj
@@ -465,7 +465,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.2;
+				MARKETING_VERSION = 3.2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -490,7 +490,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.2;
+				MARKETING_VERSION = 3.2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac.extension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -518,7 +518,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.2;
+				MARKETING_VERSION = 3.2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
@@ -545,7 +545,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
-				MARKETING_VERSION = 3.2;
+				MARKETING_VERSION = 3.2.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = archive.org.waybackmachine.mac;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.3",
+  "version": "3.3.0.1",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Wayback Machine",
-  "version": "3.2",
+  "version": "3.2.0.1",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/login.js
+++ b/webextension/scripts/login.js
@@ -40,7 +40,22 @@ function doLogin(e) {
   }
   $('#login-btn').val('Please Wait...')
   // need to set test-cookie for login API to return json instead of html
-  chrome.cookies.set({ url: 'https://archive.org', name: 'test-cookie', value: '1' })
+  chrome.cookies.set({ url: 'https://archive.org', name: 'test-cookie', value: '1' }, (cookie) => {
+    if (!cookie) {
+      // failed to set cookie
+      console.log("Cookie access is blocked. Please check cookie settings.")
+      console.log("This could happen if 'privacy.firstparty.isolate' is set to true.")
+      $('#login-message').show().text("Please Enable Cookies")
+      $('#login-btn').val('Login')
+    }
+    else {
+      // cookie was set
+      doLoginAPI(email, password)
+    }
+  })
+}
+
+function doLoginAPI(email, password) {
   let data = JSON.stringify({ email: email, password: password })
   const loginPromise = new Promise((resolve, reject) => {
     setTimeout(() => {

--- a/webextension/scripts/login.js
+++ b/webextension/scripts/login.js
@@ -78,17 +78,28 @@ function doLoginAPI(email, password) {
         // login failed
         $('#login-message').show().text('Incorrect Email or Password')
       } else {
-        // login success
-        $('#login-message').show().addClass('login-success').text('Success')
-        loginSuccess()
-        setTimeout(() => {
-          $('#login-page').hide()
-          $('#setting-page').hide()
-          $('#popup-page').show()
-          $('#login-message').removeClass('login-success').hide()
-        }, 500)
-        $('#email-input').val('')
-        $('#password-input').val('')
+        // this will check that we have cookie access
+        checkAuthentication((result) => {
+          checkLastError()
+          if (result && result.auth_check) {
+            // login success
+            $('#login-message').show().addClass('login-success').text('Success')
+            loginSuccess()
+            setTimeout(() => {
+              $('#login-page').hide()
+              $('#setting-page').hide()
+              $('#popup-page').show()
+              $('#login-message').removeClass('login-success').hide()
+            }, 500)
+            $('#email-input').val('')
+            $('#password-input').val('')
+          } else {
+            // failed cookie access check
+            console.log("Cookie access is blocked. Please check cookie settings.")
+            $('#login-message').show().text("Please Enable Cookies")
+            $('#login-btn').val('Login')
+          }
+        })
       }
     })
     .catch((e) => {

--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -177,7 +177,7 @@ function getUserInfo() {
 function checkAuthentication(acallback) {
   chrome.cookies.getAll({ url: 'https://archive.org' }, (cookies) => {
     let loggedIn = false, ia_auth = false
-    cookies.forEach(cookie => {
+    cookies && cookies.forEach(cookie => {
       if ((cookie.name === 'logged-in-sig') && cookie.value && (cookie.value.length > 0)) { loggedIn = true }
       else if ((cookie.name === 'ia-auth') && cookie.value && (cookie.value.length > 0)) { ia_auth = true }
     })


### PR DESCRIPTION
Performs some checks on whether extension can access cookies and informs the user when they login to _Please Enable Cookies_.

- Catches case when `privacy.firstparty.isolate` variable in Firefox is set true. See #983
- Catches when All Cookies are blocked in browser settings. (which usually also prevents websites from working correctly.)

