### PR TITLE
Extract context_url directly from context api response

### DIFF
--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -909,43 +909,18 @@ function factCheck(atab, url) {
     getCachedFactCheck(url,
       (json) => {
         // json is an object containing:
-        //   "notices": [ { "notice": "...", "where": { "timestamp": [ "-yyyymmdd123456" ] } } ],
+        //   "notices": [ { "notice": "...", "context_url": "..." } ],
         //   "status": "success"
 
         // parse notices from result
         if (json && ('status' in json) && (json.status === 'success') && ('notices' in json) && json.notices && (json.notices.length > 0)) {
-          // Create a Wayback Machine URL from most recent timestamp, or the latest capture if no timestamp returned.
-          // If multiple notices, pick notice with most recent timestamp.
-
-          // let latestTimestamp = '2' // latest capture in Wayback Machine URL
-          // let latestDate = new Date(0) // epoch 1/1/1970
-
-          // loop through every timestamp present
-          // json.notices.forEach(ntc => {
-          //   if (('where' in ntc) && ntc.where && ('timestamp' in ntc.where)) {
-          //     const tstamps = ntc.where.timestamp || []
-          //     tstamps.forEach(tstamp => {
-          //       // compare each timestamp to latest
-          //       const timestamp = (tstamp.charAt(0) === '-') ? tstamp.slice(1) : tstamp // remove leading dash
-          //       const date = timestampToDate(timestamp)
-          //       if (date.getTime() > latestDate.getTime()) {
-          //         latestDate = date
-          //         latestTimestamp = timestamp
-          //       }
-          //     })
-          //   }
-          // })
-
-          // extract context URL from notice text, if present
-          if ('notice' in json.notices[0]) {
-            const aMatch = (json.notices[0]['notice']).match(/href="([^"]*)/)
-            if (aMatch) {
-              const contextUrl = aMatch[1]
-              if (contextUrl !== url) {
-                // only show context button if URL different than current URL in address bar
-                saveTabData(atab, { 'contextUrl': contextUrl })
-                addToolbarState(atab, 'F')
-              }
+          // extract context URL if present
+          if ('context_url' in json.notices[0]) {
+            const contextUrl = json.notices[0]['context_url']
+            if (contextUrl !== url) {
+              // only show context button if URL different than current URL in address bar
+              saveTabData(atab, { 'contextUrl': contextUrl })
+              addToolbarState(atab, 'F')
             }
           }
         }


### PR DESCRIPTION
There is a change in the backend context service so that context_url is directly available in the api response.
Just need to check if the context_url key is available in the response and then show the yellow dot with button in the UI