### PR TITLE
Allow silent Save Page Now to save to My Web Archive

### DIFF
--- a/webextension/index.html
+++ b/webextension/index.html
@@ -275,6 +275,10 @@
         <span class="auth-icon"><input type="checkbox" class="saved-setting clear-on-logout" id="my-archive-setting"></span>
         <div class="setting-text-box">
           <span class="toggle auth-dim">Save To My Web Archive</span>
+          <div style="margin-top: 0.5em; line-height: 1em">
+            <input type="checkbox" class="saved-setting clear-on-logout" id="auto-my-archive-setting">
+            <label for="auto-my-archive-setting" id="auto-my-archive-label" style="margin-top: 5px; font-size: 11px;">always save</label>
+          </div>
         </div>
       </label>
       <label class="setting-switch" for="resource-list-setting">

--- a/webextension/scripts/settings.js
+++ b/webextension/scripts/settings.js
@@ -35,6 +35,7 @@ function restoreSettings(items) {
   $('#tvnews-setting').prop('checked', items.tvnews_setting)
   // second panel
   $('#auto-archive-setting').prop('checked', items.auto_archive_setting)
+  $('#auto-my-archive-setting').prop('checked', items.auto_my_archive_setting)
   $('#auto-archive-age').val(items.auto_archive_age || '99999')
   $('#auto-bookmark-setting').prop('checked', items.auto_bookmark_setting)
   $('#email-outlinks-setting').prop('checked', items.email_outlinks_setting)
@@ -62,6 +63,7 @@ function saveSettings() {
     tvnews_setting: $('#tvnews-setting').prop('checked'),
     // second panel
     auto_archive_setting: $('#auto-archive-setting').prop('checked'),
+    auto_my_archive_setting: $('#auto-my-archive-setting').prop('checked'),
     auto_archive_age: $('#auto-archive-age').val(),
     auto_bookmark_setting: $('#auto-bookmark-setting').prop('checked'),
     email_outlinks_setting: $('#email-outlinks-setting').prop('checked'),
@@ -121,6 +123,17 @@ function setupSettingsChange() {
   $('#auto-archive-age').change((e) => {
     $('#auto-archive-setting').prop('checked', true).trigger('change')
     e.target.blur()
+  })
+  $('#my-archive-setting').change((e) => {
+    if ($(e.target).prop('checked') === true) {
+      $('#auto-my-archive-setting').attr('disabled', false)
+      $('#auto-my-archive-label').css('opacity', '1.0').css('cursor', '')
+    } else {
+      $('#auto-my-archive-setting').prop('checked', false).trigger('change')
+      $('#auto-my-archive-setting').attr('disabled', true)
+      $('#auto-my-archive-label').css('opacity', '0.66').css('cursor', 'not-allowed')
+      e.target.blur()
+    }
   })
 
   // auto save bookmarks
@@ -242,7 +255,7 @@ function setupHelpDocs() {
     'auto-archive-setting': 'Archive URLs that have not previously been archived to the Wayback Machine.',
     'auto-bookmark-setting': 'Archive when bookmarking a website, except Excluded URLs.',
     'email-outlinks-setting': 'Send an email of results when Outlinks option is selected.',
-    'my-archive-setting': 'Adds URL to My Web Archive when Save Page Now is selected.',
+    'my-archive-setting': 'Adds URL to My Web Archive only when Save Page Now is triggered (unless "always save" is turned on).',
     'notify-setting': 'Turn off all notifications.',
     'resource-list-setting': 'Display embedded URLs archived with Save Page Now.'
   }


### PR DESCRIPTION
This PR adds an option to `always save` to My Web Archive when it is not explicitly triggered by the clicking "Save Page Now" button. This means that archives that were triggered by Auto Save or Bookmark features will be saved to My Web Archive. Implements #1024.