### PR TITLE
Auto exclude *.discord.com/api/webhooks/*

### DIFF
--- a/webextension/scripts/utils.js
+++ b/webextension/scripts/utils.js
@@ -11,6 +11,7 @@ const defaultAutoExcludeList = [
   '*.google.com*',
   'mail.yahoo.com*',
   'duckduckgo.com/?q=*',
+  '*.discord.com/api/webhooks/*',
   '*.proton.me*'
 ]
 


### PR DESCRIPTION
Fixing issue: https://github.com/internetarchive/wayback-machine-webextension/issues/1017