### PR TITLE
Make welcome content more readable

### DIFF
--- a/webextension/css/welcome.css
+++ b/webextension/css/welcome.css
@@ -30,15 +30,21 @@ header {
     text-align: center;
 }
 
+main, .bottom {
+    max-inline-size: min(60ch, 100%);
+    margin-inline: auto;
+    padding-inline: 16px;
+}
+
 main {
-    margin: 2em 15vw 10vh 15vw;
+    margin-block: 2em 10vh;
     padding-bottom: 5em;
 }
 
 .bottom-container {
     position: fixed;
     margin: 0;
-    padding: 0.5em 15vw 0.5em 15vw;
+    padding-block: 0.5em;
     bottom: 0;
     left: 0;
     right: 0;

--- a/webextension/welcome.html
+++ b/webextension/welcome.html
@@ -3,6 +3,7 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
     <link rel="stylesheet" type="text/css" href="css/common.css">
     <link rel="stylesheet" type="text/css" href="css/welcome.css">
@@ -71,12 +72,14 @@
       </main>
 
       <div class="bottom-container">
-        <button type="submit" name="accept-terms" id="accept-btn" class="btn btn-auto btn-blue">
-          <span>Accept and Enable</span>
-        </button>
-        <button type="submit" name="decline-terms" id="decline-btn" class="btn btn-auto btn-dark-gray">
-          <span>Cancel</span>
-        </button>
+        <div class="bottom">
+          <button type="submit" name="accept-terms" id="accept-btn" class="btn btn-auto btn-blue">
+            <span>Accept and Enable</span>
+          </button>
+          <button type="submit" name="decline-terms" id="decline-btn" class="btn btn-auto btn-dark-gray">
+            <span>Cancel</span>
+          </button>
+        </div>
       </div>
 
     </div>


### PR DESCRIPTION
Required for #1013.

The welcome content can be quite unreadable across certain screen sizes.

1. Firefox for Linux mobile implies that `<meta name="viewport" content="width=device-width, initial-scale=1.0">` is already present. This makes the lines in the content very short, which is annoying to read.
2. Firefox for Android doesn't imply that `<meta name="viewport" content="width=device-width, initial-scale=1.0">` is already present. This makes the content appear to be very zoomed out, making the actual text appear very small and hard to read.
3. Firefox for desktop on a widescreen monitor makes the text span a lot of the monitor. Since it's [recommended by the WCAG to not exceed 80 characters per line](https://www.w3.org/TR/WCAG22/#visual-presentation) for accessibility purposes, I've clamped the line width. Note that I didn't ensure that we're actually clamping up to 80 characters and no more due to the way `ch` works (our best bet of achieving this). In order to get about 80 characters per line, I set the width to `60ch`, as [recommended by Eric Meyers](https://meyerweb.com/eric/thoughts/2018/06/28/what-is-the-css-ch-unit/).

Note that, since this extension is only installable on Firefox desktop and Firefox on a Linux phone, the Firefox on Android "screenshot" was created via the Responsive Design Mode in Firefox Dev Tools. It is, however, very representative of what it'd look like on Android.

|Device|Before|After|
|---|---|---|
|Firefox on Linux mobile|<img width="1081" height="1921" alt="Screen Shot 2025-10-31 at 21 26 15" src="https://github.com/user-attachments/assets/c0201071-893b-4a63-9842-5661d2e35cac" />|<img width="1081" height="1921" alt="Screen Shot 2025-10-31 at 21 27 43" src="https://github.com/user-attachments/assets/a4380818-c814-484e-8bfd-f447b065afb8" />|
|Firefox on Android (theoretically)|<img width="980" height="1742" alt="Screenshot 2025-11-02 at 12-43-34 Welcome to the Internet Archive&#39;s Wayback Machine Extension!" src="https://github.com/user-attachments/assets/40806a19-ffc9-4eee-86f4-a9487f93bf4d" />|<img width="1081" height="1921" alt="Screen Shot 2025-10-31 at 21 27 43" src="https://github.com/user-attachments/assets/a4380818-c814-484e-8bfd-f447b065afb8" />|
|Widescreen monitor on Firefox desktop|<img width="7875" height="2625" alt="Screen Shot 2025-10-31 at 21 27 01" src="https://github.com/user-attachments/assets/9a901827-7bcd-4a62-8717-526c2e08229f" />|<img width="7875" height="2625" alt="Screen Shot 2025-10-31 at 21 27 39" src="https://github.com/user-attachments/assets/1e031551-2eaf-46a5-98f3-3eee9b5564b6" />|

