### PR TITLE
Display extra SPN system status when capture fails

### DIFF
--- a/webextension/index.html
+++ b/webextension/index.html
@@ -24,6 +24,7 @@
 
       <div id="url-not-supported-msg"></div>
       <div id="wayback-count-msg">&nbsp;</div>
+      <div id="spn-system-status-msg"></div>
       <div id="using-search-msg"></div>
       <div id="last-saved-msg">&nbsp;</div>
 


### PR DESCRIPTION
Check SPN system to detect potential general issues (e.g. SPN is overloaded) or user account issues (e.g. the user did too many requests today) and display extra info.

