### PR TITLE
Make banner scale with viewport

### DIFF
--- a/webextension/css/welcome.css
+++ b/webextension/css/welcome.css
@@ -54,8 +54,9 @@ main {
 }
 
 .welcome-logo {
-    width: 375px;
-    height: 150px;
+    width: 100%;
+    max-width: 375px;
+    height: auto;
     margin: 0 auto;
 }
 


### PR DESCRIPTION
Required for https://github.com/internetarchive/wayback-machine-webextension/issues/1013.

On screens with a width less than 375px, the banner is not only cut off, but it also causes the action buttons at the bottom of the screen to be invisible. This means that people with screens that are less than 375px can't get past the ToC screen.

|Before|After|
|---|---|
|<img width="600" height="1200" alt="Screen Shot 2025-11-26 at 21 45 56" src="https://github.com/user-attachments/assets/f5499c63-115f-4375-bce0-9992f74419e6" />|<img width="600" height="1200" alt="Screen Shot 2025-11-26 at 21 46 05" src="https://github.com/user-attachments/assets/e679283a-b126-435d-a925-4f7fdc46602f" />|