### PR TITLE
Add viewport meta tags to all extension pages

### DIFF
--- a/webextension/about.html
+++ b/webextension/about.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/about.css">

--- a/webextension/annotations.html
+++ b/webextension/annotations.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/context.css">

--- a/webextension/cited-books.html
+++ b/webextension/cited-books.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/cited-books.css">

--- a/webextension/cited-papers.html
+++ b/webextension/cited-papers.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/cited-papers.css">

--- a/webextension/exclude-list.html
+++ b/webextension/exclude-list.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/exclude-list.css">

--- a/webextension/index.html
+++ b/webextension/index.html
@@ -4,6 +4,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wayback Machine</title>
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">

--- a/webextension/resource-list.html
+++ b/webextension/resource-list.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/resource-list.css">

--- a/webextension/tvnews.html
+++ b/webextension/tvnews.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>TV News Clips</title>
   <link rel="stylesheet" href="css/bootstrap.css">
   <link rel="stylesheet" href="css/common.css">

--- a/webextension/wordcloud.html
+++ b/webextension/wordcloud.html
@@ -3,6 +3,7 @@
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="stylesheet" type="text/css" href="css/bootstrap.css">
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/context.css">


### PR DESCRIPTION
Required for https://github.com/internetarchive/wayback-machine-webextension/issues/1013.

Per the [Firefox for Android extension checklist](https://extensionworkshop.com/documentation/develop/developing-extensions-for-firefox-for-android/), this is a required step:

> Make sure HTML pages have [viewport meta tags](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag#viewport_basics) to scale your extension's UI on mobile screens properly.

I took it for a spin on my Android phone, and things are already looking a lot better since the websites are being scaled to the device, instead of looking like a desktop website fully zoomed out.

Here's a couple of examples:

|Before|After|
|---|---|
|<img width="1080" height="1920" alt="Screenshot_20251126-225404_Firefox" src="https://github.com/user-attachments/assets/c5f51a04-bdd2-4348-8c9b-1ba3ebb46c0b" />|<img width="1080" height="1920" alt="Screenshot_20251126-225450_Firefox" src="https://github.com/user-attachments/assets/973d4c3b-fb58-4d00-9d5a-b4e4a7d258c6" />|
|<img width="1080" height="1920" alt="Screenshot_20251126-225419_Firefox" src="https://github.com/user-attachments/assets/2f5a3d54-ab1f-469b-a6d1-9fbf318b6c9c" />|<img width="1080" height="1920" alt="Screenshot_20251126-225323_Firefox" src="https://github.com/user-attachments/assets/47c5381e-c0a4-446e-982d-f9e5cfcf91fe" />|