### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ In cooperation with [Google Summer of Code](https://summerofcode.withgoogle.com)
 
 Follow the link below to install the latest deployed version for your web browser.
 
-| [![Chrome](webextension/images/about/chrome64.png)<br> Chrome](https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak) | [![Edge](webextension/images/about/edge64.png)<br> Edge](https://microsoftedge.microsoft.com/addons/detail/wayback-machine/kjmickeoogghaimmomagaghnogelpcpn) | [![Firefox](webextension/images/about/firefox64.png)<br> Firefox](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/) | [![Safari](webextension/images/about/safari64.png)<br> Safari](https://apps.apple.com/us/app/wayback-machine/id1472432422?mt=12) |
+| [![Chrome](webextension/images/about/chrome64.png)<br> Chrome](https://chromewebstore.google.com/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak) | [![Edge](webextension/images/about/edge64.png)<br> Edge](https://microsoftedge.microsoft.com/addons/detail/wayback-machine/kjmickeoogghaimmomagaghnogelpcpn) | [![Firefox](webextension/images/about/firefox64.png)<br> Firefox](https://addons.mozilla.org/en-US/firefox/addon/wayback-machine_new/) | [![Safari](webextension/images/about/safari64.png)<br> Safari](https://apps.apple.com/us/app/wayback-machine/id1472432422?mt=12) |
 | -- | -- | -- | -- |
 
 

--- a/appstores/chrome/README.md
+++ b/appstores/chrome/README.md
@@ -4,7 +4,7 @@
 - [Old Changelog](changelog-chrome.md).
 
 - Store ID: fpnmgdkabkmnadcjpehmlllkndpkmiak
-- Store URL: https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak
+- Store URL: https://chromewebstore.google.com/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak
 
 
 ### Notes
@@ -35,7 +35,7 @@ zip -r webext.zip . -x ".*" -x "*/.*"
   - Use standard app email account and password.
   - This will send a verification code SMS to number listed, who you will need to ask for the code.
 
-- After login, go to the [Developer Dashboard](https://chrome.google.com/webstore/devconsole/).
+- After login, go to the [Developer Dashboard](https://chromewebstore.google.com/devconsole/).
 
 - You can manage the account by selecting "Account" from the upper left menu.
 

--- a/webextension/about.html
+++ b/webextension/about.html
@@ -102,7 +102,7 @@
         <h3>Web Extensions</h3>
         <p>
           <img src="images/about/chrome64.png" class="about-app-icon" alt="Chrome Extension">
-          <a href="https://chrome.google.com/webstore/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak" target="_blank">Chrome Extension</a><br>
+          <a href="https://chromewebstore.google.com/detail/wayback-machine/fpnmgdkabkmnadcjpehmlllkndpkmiak" target="_blank">Chrome Extension</a><br>
 
           <img src="images/about/edge64.png" class="about-app-icon" alt="Edge Add-On">
           <a href="https://microsoftedge.microsoft.com/addons/detail/wayback-machine/kjmickeoogghaimmomagaghnogelpcpn" target="_blank">Edge Add-On</a><br>


### PR DESCRIPTION
Updates Chrome Web Store URLs from the deprecated `chrome.google.com/webstore` domain to `chromewebstore.google.com`.

Google has migrated the Chrome Web Store to the new domain. The old URLs currently redirect but may stop working in the future.

No functional changes — documentation only.
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*