### PR TITLE
Fix Bootstrap 5 compatibility: disabled buttons, progress bar, and SPN  logged-out state

### DIFF
--- a/webextension/css/common.css
+++ b/webextension/css/common.css
@@ -102,22 +102,28 @@ button:disabled {
     box-shadow: none !important;
 }
 
-/* Preserve original button colors for disabled state - override hover/active states */
+/* Preserve original button colors for disabled state - override Bootstrap 5's
+   .btn:disabled which uses undefined CSS vars that resolve to transparent */
+.btn-red:disabled,
 .btn-red:disabled:hover,
 .btn-red:disabled:active,
-.btn-red:disabled:focus { background-color: #9A3B38 !important; border-color: #BF4946 !important; }
+.btn-red:disabled:focus { background-color: #9A3B38 !important; border-color: #BF4946 !important; color: #eee !important; }
+.btn-light-gray:disabled,
 .btn-light-gray:disabled:hover,
 .btn-light-gray:disabled:active,
-.btn-light-gray:disabled:focus { background-color: #737373 !important; border-color: #A9A9A9 !important; }
+.btn-light-gray:disabled:focus { background-color: #737373 !important; border-color: #A9A9A9 !important; color: #eee !important; }
+.btn-dark-gray:disabled,
 .btn-dark-gray:disabled:hover,
 .btn-dark-gray:disabled:active,
-.btn-dark-gray:disabled:focus { background-color: #4D4D4D !important; border-color: #737373 !important; }
+.btn-dark-gray:disabled:focus { background-color: #4D4D4D !important; border-color: #737373 !important; color: #eee !important; }
+.btn-yellow:disabled,
 .btn-yellow:disabled:hover,
 .btn-yellow:disabled:active,
-.btn-yellow:disabled:focus { background-color: #AA8800 !important; border-color: #EECC00 !important; }
+.btn-yellow:disabled:focus { background-color: #AA8800 !important; border-color: #EECC00 !important; color: #eee !important; }
+.btn-blue:disabled,
 .btn-blue:disabled:hover,
 .btn-blue:disabled:active,
-.btn-blue:disabled:focus { background-color: #405971 !important; border-color: #668db3 !important; }
+.btn-blue:disabled:focus { background-color: #405971 !important; border-color: #668db3 !important; color: #eee !important; }
 
 /* button sizes */
 
@@ -298,16 +304,27 @@ button.selected:focus-visible {
     margin: 0;
     overflow: hidden;
     border-radius: 5px;
+    background-color: transparent; /* Override Bootstrap 5's light gray bg so .btn-red parent shows through */
 }
 
 .progress-bar {
     background-color: #9A3B38;
+    height: 100%;
+}
+
+.progress-bar-striped {
+    background-size: 40px 40px; /* Override Bootstrap 5's 1rem stripes to match original larger stripes */
 }
 
 .progress-bar.active {
     -webkit-animation: progress-bar-stripes 0.5s linear infinite;
     -o-animation: progress-bar-stripes 0.5s linear infinite;
     animation: progress-bar-stripes 0.5s linear infinite;
+}
+
+@keyframes progress-bar-stripes {
+    from { background-position: 40px 0; }
+    to { background-position: 0 0; }
 }
 
 /* Dark Mode */

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Wayback Machine",
-  "version": "3.4.7",
+  "version": "3.4.8",
   "description": "The Official Wayback Machine Extension - by the Internet Archive.",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",

--- a/webextension/scripts/background.js
+++ b/webextension/scripts/background.js
@@ -41,9 +41,7 @@ let tabIdPromise
 //
 function savePageNowChecked(atab, pageUrl, silent, options) {
   checkAuthentication((results) => {
-    if (results?.auth_check) {
-      savePageNow(atab, pageUrl, silent, options, results.auth_check)
-    }
+    savePageNow(atab, pageUrl, silent, options, results?.auth_check || false)
   })
 }
 


### PR DESCRIPTION
 Fix Bootstrap 5 compatibility: disabled buttons, progress bar, and SPN  logged-out state
  - Preserve custom button colors in disabled state by adding :disabled base
    selectors to override Bootstrap 5's .btn:disabled which uses undefined CSS
    variables that resolve to transparent, making buttons invisible in light
  mode
  - Set .progress background to transparent so .btn-red parent shows through
    instead of Bootstrap 5's light gray secondary-bg
  - Restore progress bar stripe animation by adding explicit height, larger
    background-size, and original keyframes that Bootstrap 5 changed
  - Fix Save Page Now not working when logged out: remove auth_check gate in
    savePageNowChecked so savePageNow is always called with the correct flag