### PR TITLE
Add i18n infrastructure using chrome.i18n API

### DIFF
--- a/webextension/_locales/en/messages.json
+++ b/webextension/_locales/en/messages.json
@@ -1,0 +1,42 @@
+{
+  "ext_name": {
+    "message": "Wayback Machine",
+    "description": "Name of the extension."
+  },
+  "ext_description": {
+    "message": "The Official Wayback Machine Extension - by the Internet Archive.",
+    "description": "Description of the extension."
+  },
+  "exclude_title": {
+    "message": "Exclude URLs",
+    "description": "Title shown on the Exclude URLs page."
+  },
+  "exclude_description": {
+    "message": "Enter URL patterns below to exclude from Auto Save.",
+    "description": "Instructions on the Exclude URLs page."
+  },
+  "exclude_clear_all": {
+    "message": "Clear All",
+    "description": "Button to clear all excluded URL patterns."
+  },
+  "exclude_reset_defaults": {
+    "message": "Reset to Defaults",
+    "description": "Button to reset excluded URL patterns to defaults."
+  },
+  "exclude_placeholder": {
+    "message": "Enter 1 URL per line. For example: archive.org*",
+    "description": "Placeholder text for the exclude list textarea."
+  },
+  "exclude_legend": {
+    "message": "Use * as a wildcard. For example: archive.org*",
+    "description": "Help text explaining wildcard usage in the exclude list."
+  },
+  "exclude_cancel": {
+    "message": "Cancel",
+    "description": "Button to cancel changes to the exclude list."
+  },
+  "exclude_save": {
+    "message": "Save",
+    "description": "Button to save changes to the exclude list."
+  }
+}

--- a/webextension/exclude-list.html
+++ b/webextension/exclude-list.html
@@ -8,37 +8,38 @@
   <link rel="stylesheet" type="text/css" href="css/common.css">
   <link rel="stylesheet" type="text/css" href="css/exclude-list.css">
   <link rel="icon" type="image/png" href="images/toolbar/toolbar-icon-archive32.png">
-  <title>Exclude URLs</title>
+  <title data-i18n="exclude_title">Exclude URLs</title>
 </head>
 <body>
   <div class="body-container">
 
     <header>
-      <h4 id="main-title">Exclude URLs</h4>
-      <p id="main-info">Enter URL patterns below to exclude from Auto Save.</p>
+      <h4 id="main-title" data-i18n="exclude_title">Exclude URLs</h4>
+      <p id="main-info" data-i18n="exclude_description">Enter URL patterns below to exclude from Auto Save.</p>
     </header>
 
     <main>
 
       <div class="btn-flex-block">
-        <button class="btn btn-auto btn-dark-gray" id="clear-btn">Clear All</button>
-        <button class="btn btn-auto btn-dark-gray" id="reset-btn">Reset to Defaults</button>
+        <button class="btn btn-auto btn-dark-gray" id="clear-btn" data-i18n="exclude_clear_all">Clear All</button>
+        <button class="btn btn-auto btn-dark-gray" id="reset-btn" data-i18n="exclude_reset_defaults">Reset to Defaults</button>
       </div>
 
       <div id="exclude-list-container">
-        <textarea id="exclude-list-area" class="form-control" placeholder="Enter 1 URL per line. For example: archive.org*" autofocus></textarea>
+        <textarea id="exclude-list-area" class="form-control" data-i18n-placeholder="exclude_placeholder" placeholder="Enter 1 URL per line. For example: archive.org*" autofocus></textarea>
       </div>
 
       <div class="btn-flex-block">
-        <div id="legend-info">Use * as a wildcard. For example:<br>archive.org*</div>
-        <button class="btn btn-auto btn-dark-gray" id="cancel-btn">Cancel</button>
-        <button class="btn btn-auto btn-red" id="save-btn">Save</button>
+        <div id="legend-info" data-i18n="exclude_legend">Use * as a wildcard. For example: archive.org*</div>
+        <button class="btn btn-auto btn-dark-gray" id="cancel-btn" data-i18n="exclude_cancel">Cancel</button>
+        <button class="btn btn-auto btn-red" id="save-btn" data-i18n="exclude_save">Save</button>
       </div>
 
     </main>
 
   </div>
 
+  <script src="scripts/i18n.js"></script>
   <script src="libs/jquery.js"></script>
   <script src="libs/bootstrap.js"></script>
   <script src="scripts/utils.js"></script>

--- a/webextension/manifest.json
+++ b/webextension/manifest.json
@@ -1,8 +1,9 @@
 {
   "manifest_version": 3,
-  "name": "Wayback Machine",
+  "name": "__MSG_ext_name__",
   "version": "3.4.8",
-  "description": "The Official Wayback Machine Extension - by the Internet Archive.",
+  "description": "__MSG_ext_description__",
+  "default_locale": "en",
   "icons": {
     "16": "images/app-icon/mini-icon16.png",
     "24": "images/app-icon/mini-icon24.png",

--- a/webextension/scripts/i18n.js
+++ b/webextension/scripts/i18n.js
@@ -1,0 +1,34 @@
+/* global chrome */
+
+/**
+ * Applies i18n translations to DOM elements using data attributes.
+ *
+ * Supported attributes:
+ *   data-i18n="key"             → sets textContent
+ *   data-i18n-placeholder="key" → sets placeholder
+ *   data-i18n-title="key"       → sets title
+ *   data-i18n-value="key"       → sets value (for input/button)
+ *   data-i18n-aria-label="key"  → sets aria-label
+ */
+function applyI18n() {
+  const attrMap = {
+    'i18n': function (el, msg) { el.textContent = msg },
+    'i18n-placeholder': function (el, msg) { el.placeholder = msg },
+    'i18n-title': function (el, msg) { el.title = msg },
+    'i18n-value': function (el, msg) { el.value = msg },
+    'i18n-aria-label': function (el, msg) { el.setAttribute('aria-label', msg) }
+  }
+
+  Object.keys(attrMap).forEach(function (attr) {
+    const selector = '[data-' + attr + ']'
+    document.querySelectorAll(selector).forEach(function (el) {
+      const key = el.getAttribute('data-' + attr)
+      const msg = chrome.i18n.getMessage(key)
+      if (msg) {
+        attrMap[attr](el, msg)
+      }
+    })
+  })
+}
+
+document.addEventListener('DOMContentLoaded', applyI18n)


### PR DESCRIPTION
## Summary

- Set up `default_locale` and `__MSG_` syntax in `manifest.json`
- Create `_locales/en/messages.json` with English strings
- Add shared `scripts/i18n.js` helper that translates DOM elements via `data-i18n` attributes (supports `textContent`, `placeholder`, `title`, `value`, `aria-label`)
- Migrate `exclude-list.html` as a working example, demonstrating both `data-i18n` and `data-i18n-placeholder` attribute types

This is **Phase 1** of i18n support (refs #1073, #379). It establishes the framework so that remaining pages can be migrated incrementally in follow-up PRs. Inspired by the `data-i18n` approach shared in #847.

The standard `_locales/messages.json` format is natively supported by translation platforms like [Weblate](https://weblate.org/) and [Crowdin](https://crowdin.com/) (discussed in #379), making it easy to onboard community translators in a future phase.

### Cross-browser compatibility

`chrome.i18n` is supported by all browsers that support Manifest v3. Tested on Chrome, Firefox, Edge, and Safari — no browser-specific code needed.

> **Note for Safari App Store builds:** The new `_locales/` directory will need to be added to the Xcode project as a folder reference before the next release.

### Next phases

- **Phase 2:** Migrate remaining HTML pages and JS dynamic strings incrementally
- **Phase 3:** Add community translations (e.g. zh_CN, es, fr) — can integrate with Weblate/Crowdin as discussed in #379

## Test plan

- [x] `npm run lint` passes (0 errors)
- [x] `npm test` passes (229/229, 1 pre-existing timezone failure unrelated)
- [x] Chrome — extension name and exclude-list page display correctly
- [x] Firefox — loaded via `about:debugging`, displays correctly
- [x] Edge — loaded via `edge://extensions`, displays correctly
- [x] Safari — loaded via Develop → Add Temporary Extension, displays correctly