### PR TITLE
Fix SyntaxError in archive.js preventing 404 popup banner

### DIFF
--- a/webextension/scripts/archive.js
+++ b/webextension/scripts/archive.js
@@ -63,7 +63,8 @@ function popupWayback(url, code) {
   // Adding functionality to close and archive button
   gShadowRoot.querySelector('#close-btn')?.addEventListener('click', () => {
     gCloseClicked = true
-    gShadowRoot.querySelector('#popup-container')?.style.display = 'none'
+    const popup = gShadowRoot.querySelector('#popup-container')
+    if (popup) { popup.style.display = 'none' }
   })
 
   gShadowRoot.querySelector('#archive-btn')?.addEventListener('click', (e) => {


### PR DESCRIPTION
Fix for issue #1114. Optional chaining (`?.`) on the left-hand side of an assignment is [invalid JavaScript](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#invalid_optional_chaining), causing `archive.js` to fail to parse and the "pop-up in page" banner to never appear.